### PR TITLE
Implement dependency graph model

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -3,14 +3,14 @@ package graph
 import "github.com/coreos/grafiti/arn"
 
 // Hard-coded rounds of retrieval
-var r0 = []string{
+var r0 = arn.ResourceTypes{
 	arn.EC2VPCRType,
 	arn.AutoScalingGroupRType,
 	arn.Route53HostedZoneRType,
 	arn.S3BucketRType,
 }
 
-var r1 = []string{
+var r1 = arn.ResourceTypes{
 	arn.EC2NatGatewayRType,
 	arn.EC2InternetGatewayRType,
 	arn.EC2InstanceRType,
@@ -21,18 +21,18 @@ var r1 = []string{
 	arn.AutoScalingLaunchConfigurationRType,
 }
 
-var r2 = []string{
+var r2 = arn.ResourceTypes{
 	arn.EC2RouteTableAssociationRType,
 	arn.EC2EIPRType,
 	arn.EC2EIPAssociationRType,
 	arn.EC2NetworkACLRType,
 }
 
-var rounds = [][]string{r0, r1, r2}
+var rounds = []arn.ResourceTypes{r0, r1, r2}
 
 // FillDependencyGraph creates a depGraph starting from an inital set of
 // resources found by tags
-func FillDependencyGraph(initDepMap *map[string][]string) {
+func FillDependencyGraph(initDepMap *map[arn.ResourceType]arn.ResourceNames) {
 	if initDepMap == nil {
 		return
 	}
@@ -49,15 +49,15 @@ func FillDependencyGraph(initDepMap *map[string][]string) {
 }
 
 // traverseDependencyGraph traverses necesssary linkages of each resource
-func traverseDependencyGraph(rType string, depMap *map[string][]string) {
+func traverseDependencyGraph(rt arn.ResourceType, depMap *map[arn.ResourceType]arn.ResourceNames) {
 	if depMap == nil {
 		return
 	}
-	ids := (*depMap)[rType]
+	ids := (*depMap)[rt]
 	if ids == nil {
 		return
 	}
-	switch rType {
+	switch rt {
 	case arn.EC2VPCRType:
 		// Get Subnets
 		// Get Instances

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -9,45 +9,45 @@ import (
 
 func TestFillDependencyGraph(t *testing.T) {
 	cases := []struct {
-		Input    map[string][]string
-		Expected map[string][]string
+		Input    map[arn.ResourceType]arn.ResourceNames
+		Expected map[arn.ResourceType]arn.ResourceNames
 	}{
 		{
-			Input: map[string][]string{
-				arn.EC2VPCRType:                         []string{},
-				arn.AutoScalingGroupRType:               []string{},
-				arn.Route53HostedZoneRType:              []string{},
-				arn.S3BucketRType:                       []string{},
-				arn.EC2NatGatewayRType:                  []string{},
-				arn.EC2InternetGatewayRType:             []string{},
-				arn.EC2InstanceRType:                    []string{},
-				arn.EC2SubnetRType:                      []string{},
-				arn.EC2NetworkInterfaceRType:            []string{},
-				arn.EC2SecurityGroupRType:               []string{},
-				arn.EC2RouteTableRType:                  []string{},
-				arn.AutoScalingLaunchConfigurationRType: []string{},
-				arn.EC2RouteTableAssociationRType:       []string{},
-				arn.EC2EIPRType:                         []string{},
-				arn.EC2EIPAssociationRType:              []string{},
-				arn.EC2NetworkACLRType:                  []string{},
+			Input: map[arn.ResourceType]arn.ResourceNames{
+				arn.EC2VPCRType:                         arn.ResourceNames{},
+				arn.AutoScalingGroupRType:               arn.ResourceNames{},
+				arn.Route53HostedZoneRType:              arn.ResourceNames{},
+				arn.S3BucketRType:                       arn.ResourceNames{},
+				arn.EC2NatGatewayRType:                  arn.ResourceNames{},
+				arn.EC2InternetGatewayRType:             arn.ResourceNames{},
+				arn.EC2InstanceRType:                    arn.ResourceNames{},
+				arn.EC2SubnetRType:                      arn.ResourceNames{},
+				arn.EC2NetworkInterfaceRType:            arn.ResourceNames{},
+				arn.EC2SecurityGroupRType:               arn.ResourceNames{},
+				arn.EC2RouteTableRType:                  arn.ResourceNames{},
+				arn.AutoScalingLaunchConfigurationRType: arn.ResourceNames{},
+				arn.EC2RouteTableAssociationRType:       arn.ResourceNames{},
+				arn.EC2EIPRType:                         arn.ResourceNames{},
+				arn.EC2EIPAssociationRType:              arn.ResourceNames{},
+				arn.EC2NetworkACLRType:                  arn.ResourceNames{},
 			},
-			Expected: map[string][]string{
-				arn.EC2VPCRType:                         []string{},
-				arn.AutoScalingGroupRType:               []string{},
-				arn.Route53HostedZoneRType:              []string{},
-				arn.S3BucketRType:                       []string{},
-				arn.EC2NatGatewayRType:                  []string{},
-				arn.EC2InternetGatewayRType:             []string{},
-				arn.EC2InstanceRType:                    []string{},
-				arn.EC2SubnetRType:                      []string{},
-				arn.EC2NetworkInterfaceRType:            []string{},
-				arn.EC2SecurityGroupRType:               []string{},
-				arn.EC2RouteTableRType:                  []string{},
-				arn.AutoScalingLaunchConfigurationRType: []string{},
-				arn.EC2RouteTableAssociationRType:       []string{},
-				arn.EC2EIPRType:                         []string{},
-				arn.EC2EIPAssociationRType:              []string{},
-				arn.EC2NetworkACLRType:                  []string{},
+			Expected: map[arn.ResourceType]arn.ResourceNames{
+				arn.EC2VPCRType:                         arn.ResourceNames{},
+				arn.AutoScalingGroupRType:               arn.ResourceNames{},
+				arn.Route53HostedZoneRType:              arn.ResourceNames{},
+				arn.S3BucketRType:                       arn.ResourceNames{},
+				arn.EC2NatGatewayRType:                  arn.ResourceNames{},
+				arn.EC2InternetGatewayRType:             arn.ResourceNames{},
+				arn.EC2InstanceRType:                    arn.ResourceNames{},
+				arn.EC2SubnetRType:                      arn.ResourceNames{},
+				arn.EC2NetworkInterfaceRType:            arn.ResourceNames{},
+				arn.EC2SecurityGroupRType:               arn.ResourceNames{},
+				arn.EC2RouteTableRType:                  arn.ResourceNames{},
+				arn.AutoScalingLaunchConfigurationRType: arn.ResourceNames{},
+				arn.EC2RouteTableAssociationRType:       arn.ResourceNames{},
+				arn.EC2EIPRType:                         arn.ResourceNames{},
+				arn.EC2EIPAssociationRType:              arn.ResourceNames{},
+				arn.EC2NetworkACLRType:                  arn.ResourceNames{},
 			},
 		},
 	}
@@ -55,11 +55,7 @@ func TestFillDependencyGraph(t *testing.T) {
 	for _, c := range cases {
 		FillDependencyGraph(&c.Input)
 
-<<<<<<< HEAD
 		if !reflect.DeepEqual(c.Input, c.Expected) {
-=======
-		if reflect.DeepEqual(c.Input, c.Expected) {
->>>>>>> 2d3f39c... graph/: added tests
 			t.Errorf("FillDependencyGraph failed\nwanted\n%s\ngot\n%s\n", c.Expected, c.Input)
 		}
 	}


### PR DESCRIPTION
graph/: dependency graph construction (pre-defined order) and traversal

Dependencies are best modeled as a tree, with edges being dependencies from one resource (node) to another. Mocking these relationships helps determine deletion order as well: delete from the bottom up prevents orphans, and in AWS' case, deletion failures. The graph package constructs a dep graph from a predefined ordering of dep's (see AWS docs) and adds resources to a map based on resource order.

Tests: simple, preliminary tests. will have more after refactoring around types (#27)