### PR TITLE
Time windowing for cloudtrail event parsing

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,9 @@
 [grafiti]
 resourceType = "AWS::EC2::Instance"
-hours = -8
+endHour = 0
+startHour = -8
+# endTimeStamp = "20170614T010101Z" # ISO-8601 format in UTC
+# startTimeStamp = "20170613T010101Z"
 backoffTime = 1000 # 1 second in milliseconds
 az = "us-east-1"
 includeEvent = false

--- a/testdata/config/test-config.toml
+++ b/testdata/config/test-config.toml
@@ -1,6 +1,10 @@
 [grafiti]
-# resourceTypes = ["AWS::EC2::Instance"]
-hours = -8
+resourceTypes = ["AWS::EC2::Instance"]
+endHour = 0
+startHour = -8
+# endTimeStamp = "20170614T010101Z" # ISO-8601 format in UTC
+# startTimeStamp = "20170613T010101Z"
+backoffTime = 1000 # 1 second in milliseconds
 az = "us-west-2"
 includeEvent = false
 tagPatterns = [


### PR DESCRIPTION
cmd/grafiti/: instead of using a single `hours` argument from a config file, `grafiti parse` now uses `startHour` and `endHour` to determine a time window to request from the cloudtrail API.

*: updated all configs to reflect change

Fixes #4 