### PR TITLE
Delete non-rgta res types

### DIFF
--- a/arn/arn.go
+++ b/arn/arn.go
@@ -288,15 +288,8 @@ var CTUnsupportedResourceTypes = map[ResourceType]struct{}{
 // RGTAUnsupportedResourceTypes holds values the Resource Group Tagging
 // API does not support
 var RGTAUnsupportedResourceTypes = map[ResourceType]struct{}{
-	Route53HostedZoneRType:              struct{}{},
-	AutoScalingGroupRType:               struct{}{},
-	AutoScalingLaunchConfigurationRType: struct{}{},
-	AutoScalingPolicyRType:              struct{}{},
-	AutoScalingScheduledActionRType:     struct{}{},
-	IAMInstanceProfileRType:             struct{}{},
-	IAMUserRType:                        struct{}{},
-	IAMRoleRType:                        struct{}{},
-	IAMPolicyRType:                      struct{}{},
+	Route53HostedZoneRType: struct{}{},
+	AutoScalingGroupRType:  struct{}{},
 }
 
 // NamespaceForResource maps ResourceType to an ARN namespace

--- a/cmd/grafiti/delete.go
+++ b/cmd/grafiti/delete.go
@@ -20,36 +20,77 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
+	rgta "github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	rgtaiface "github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface"
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/aws/aws-sdk-go/service/route53/route53iface"
 	"github.com/coreos/grafiti/arn"
+	"github.com/coreos/grafiti/deleter"
+	"github.com/coreos/grafiti/graph"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
-var deleteFile string
+var (
+	deleteFile string
+	silent     bool
+	delAllDeps bool
+)
 
+// DeleteOrder contains the REVERSE order of deletion for all resource types
+var DeleteOrder = arn.ResourceTypes{
+	arn.EC2VPCRType,
+	arn.EC2SecurityGroupRType,
+	arn.EC2RouteTableRType, // Deletes RouteTable Routes
+	arn.EC2SubnetRType,
+	arn.EC2VolumeRType,
+	arn.EC2CustomerGatewayRType,
+	arn.EC2NetworkACLRType,
+	arn.EC2NetworkInterfaceRType,
+	arn.EC2InternetGatewayRType,
+	arn.IAMUserRType,
+	arn.IAMRoleRType, // Deletes IAM Role Policies
+	arn.IAMInstanceProfileRType,
+	arn.AutoScalingLaunchConfigurationRType,
+	arn.EC2EIPRType,
+	arn.EC2EIPAssociationRType,
+	arn.EC2NatGatewayRType,
+	arn.ElasticLoadBalancingLoadBalancerRType,
+	arn.AutoScalingGroupRType,
+	arn.EC2InstanceRType,
+	arn.EC2RouteTableAssociationRType,
+	arn.Route53HostedZoneRType, // Deletes Route53 RecordSets
+	arn.S3BucketRType,          // Delete S3 Objects
+}
+
+// DeleteInput holds a list of all tags to be deleted
 type DeleteInput struct {
-	TagFilters []*resourcegroupstaggingapi.TagFilter
+	TagFilters []*rgta.TagFilter
 }
 
 func init() {
 	RootCmd.AddCommand(deleteCmd)
-	tagCmd.PersistentFlags().StringVarP(&tagFile, "deleteFile", "i", "", "ARNs that should be deleted")
+	deleteCmd.PersistentFlags().StringVarP(&deleteFile, "delete-file", "f", "", "File of tags of resources to delete.")
+	deleteCmd.PersistentFlags().BoolVarP(&silent, "silent", "s", false, "Suppress JSON output.")
+	deleteCmd.PersistentFlags().BoolVar(&delAllDeps, "all-deps", false, "Delete all dependencies of all tagged resourcs.")
 }
 
 var deleteCmd = &cobra.Command{
 	Use:   "delete",
-	Short: "delete resources in AWS",
+	Short: "Delete resources in AWS",
 	Long:  "Delete resources in AWS. Uses the configured delete filters to decide which resources to delete.",
 	RunE:  runDeleteCommand,
 }
 
 func runDeleteCommand(cmd *cobra.Command, args []string) error {
-	if tagFile != "" {
+	if deleteFile != "" {
 		return deleteFromFile(deleteFile)
 	}
 	if err := deleteFromStdIn(); err != nil {
@@ -57,124 +98,359 @@ func runDeleteCommand(cmd *cobra.Command, args []string) error {
 	}
 	return nil
 }
-func deleteFromFile(tagFile string) error {
-	file, err := os.Open(tagFile)
+
+func deleteFromFile(fname string) error {
+	file, err := os.Open(fname)
 	if err != nil {
 		return err
 	}
 	reader := bufio.NewReader(file)
-	return delete(reader)
+	return deleteFromTags(reader)
 }
 
 func deleteFromStdIn() error {
-	return delete(os.Stdin)
+	return deleteFromTags(os.Stdin)
 }
 
-func delete(reader io.Reader) error {
-	region := viper.GetString("grafiti.az")
-	sess := session.Must(session.NewSession(
-		&aws.Config{
-			Region: aws.String(region),
-		},
-	))
-	svc := resourcegroupstaggingapi.New(sess)
+func deleteFromTags(reader io.Reader) error {
 	dec := json.NewDecoder(reader)
+	// Collect all ARN's
+	allARNs := make(arn.ResourceARNs, 0)
+
+	svc := rgta.New(session.Must(session.NewSession(
+		&aws.Config{
+			Region: aws.String(viper.GetString("grafiti.az")),
+		},
+	)))
 
 	for {
 		t, isEOF, err := decodeDeleteInput(dec)
 		if err != nil {
 			return err
 		}
-		if t == nil {
-			continue
-		}
-		// get ARNs of matching tags
-		params := &resourcegroupstaggingapi.GetResourcesInput{
-			PaginationToken: nil,
-			ResourceTypeFilters: []*string{
-				aws.String(arn.ServiceNameForResource(viper.GetString("grafiti.resourceType"))),
-			},
-			TagFilters:  t.TagFilters,
-			TagsPerPage: aws.Int64(100),
-		}
-
-		for {
-			// Get batch of matching resources
-			req, resp := svc.GetResourcesRequest(params)
-			if err := req.Send(); err != nil {
-				return err
-			}
-			arns := make([]string, len(resp.ResourceTagMappingList))
-			for _, r := range resp.ResourceTagMappingList {
-				if r.ResourceARN != nil && *r.ResourceARN != "" {
-					arns = append(arns, *r.ResourceARN)
-				}
-			}
-			if resp.PaginationToken == nil {
-				break
-			}
-			params.PaginationToken = resp.PaginationToken
-
-			if len(arns) == 0 {
-				fmt.Println("No resources match the specified tag filters")
-				return nil
-			}
-
-			fmt.Println(arns)
-
-			// Delete batch of matching resources
-			if err := deleteARNs(arns); err != nil {
-				return err
-			}
-		}
-
 		if isEOF {
 			break
 		}
-	}
+		if t == nil {
+			continue
+		}
 
-	return nil
-}
+		getARNsForResource(svc, t.TagFilters, allARNs)
 
-func deleteARNs(ARNs []string) error {
-	switch viper.GetString("grafiti.resourceType") {
-	case "AWS::EC2::Instance":
-		return deleteEC2Instances(ARNs)
-	}
-	fmt.Println("ResourceType not yet supported")
-	return nil
-}
-
-func deleteEC2Instances(ARNs []string) error {
-	instanceIDs := make([]*string, len(ARNs))
-	for _, a := range ARNs {
-		id := arn.InstanceIDFromARN(a)
-		if id != "" {
-			instanceIDs = append(instanceIDs, aws.String(id))
+		for rtk := range arn.RGTAUnsupportedResourceTypes {
+			// Request all RGTA-unsupported resources with the same tags
+			getARNsForUnsupportedResource(rtk, t.TagFilters, allARNs)
 		}
 	}
 
-	region := viper.GetString("grafiti.az")
-	sess := session.Must(session.NewSession(
-		&aws.Config{
-			Region: aws.String(region),
-		},
-	))
-	svc := ec2.New(sess)
-	params := &ec2.TerminateInstancesInput{
-		InstanceIds: instanceIDs,
-		DryRun:      aws.Bool(dryRun),
-	}
-	_, err := svc.TerminateInstances(params)
-
-	if err != nil {
-		if ignoreErrors {
-			fmt.Printf(`{"error": "%s"}\n`, err.Error())
-			return nil
-		}
+	// Delete batch of matching resources
+	if err := deleteARNs(allARNs); err != nil {
 		return err
 	}
+
+	if !silent {
+		arnsJSON, _ := json.MarshalIndent(allARNs, "", " ")
+		fmt.Printf("{\"DeletedARNs\": %s}\n", arnsJSON)
+	}
+
 	return nil
+}
+
+func getARNsForResource(svc rgtaiface.ResourceGroupsTaggingAPIAPI, tags []*rgta.TagFilter, arnList arn.ResourceARNs) {
+	// Get ARNs of matching tags
+	params := &rgta.GetResourcesInput{
+		TagFilters:  tags,
+		TagsPerPage: aws.Int64(100),
+	}
+
+	// If available, get all resourceTypes from config file
+	rts := viper.GetStringSlice("grafiti.resourceTypes")
+	if len(rts) != 0 {
+		frts := make([]*string, 0, len(rts))
+		for _, t := range rts {
+			rt := arn.ResourceType(t)
+			if _, ok := arn.RGTAUnsupportedResourceTypes[rt]; ok {
+				continue
+			}
+			frts = append(frts, aws.String(arn.NamespaceForResource(rt)))
+		}
+		params.ResourceTypeFilters = frts
+	}
+
+	for {
+		// Request a batch of matching resources
+		req, resp := svc.GetResourcesRequest(params)
+		if err := req.Send(); err != nil {
+			return
+		}
+
+		if len(resp.ResourceTagMappingList) == 0 {
+			fmt.Println("No resources match the specified tag filters")
+			return
+		}
+
+		for _, r := range resp.ResourceTagMappingList {
+			if r.ResourceARN != nil && *r.ResourceARN != "" {
+				arnList = append(arnList, arn.ResourceARN(*r.ResourceARN))
+			}
+		}
+
+		if resp.PaginationToken == nil || *resp.PaginationToken == "" {
+			break
+		}
+
+		params.PaginationToken = resp.PaginationToken
+	}
+}
+
+func getARNsForUnsupportedResource(rt arn.ResourceType, tags []*rgta.TagFilter, arnList arn.ResourceARNs) {
+	sess := session.Must(session.NewSession(
+		&aws.Config{
+			Region: aws.String(viper.GetString("grafiti.az")),
+		},
+	))
+
+	switch arn.NamespaceForResource(rt) {
+	case arn.AutoScalingNamespace:
+		getAutoScalingResourcesByTags(autoscaling.New(sess), rt, tags, arnList)
+	case arn.Route53Namespace:
+		getRoute53ResourcesByTags(route53.New(sess), rt, tags, arnList)
+	}
+}
+
+func getAutoScalingResourcesByTags(svc autoscalingiface.AutoScalingAPI, rt arn.ResourceType, rgtaTags []*rgta.TagFilter, arnList arn.ResourceARNs) {
+	if len(rgtaTags) == 0 {
+		return
+	}
+
+	// Currently only AutoScaling Groups support tagging
+	if rt != arn.AutoScalingGroupRType {
+		return
+	}
+
+	asgTags := make([]*autoscaling.Filter, 0)
+	for _, tag := range rgtaTags {
+		asgTags = append(asgTags, &autoscaling.Filter{
+			Name:   aws.String("key"),
+			Values: aws.StringSlice([]string{*tag.Key}),
+		})
+		if len(tag.Values) > 0 {
+			asgTags = append(asgTags, &autoscaling.Filter{
+				Name:   aws.String("value"),
+				Values: tag.Values,
+			})
+		}
+	}
+
+	params := &autoscaling.DescribeTagsInput{
+		Filters:    asgTags,
+		MaxRecords: aws.Int64(100),
+	}
+
+	asgNames := make(arn.ResourceNames, 0)
+	for {
+		ctx := aws.BackgroundContext()
+		resp, rerr := svc.DescribeTagsWithContext(ctx, params)
+		if rerr != nil {
+			return
+		}
+
+		if resp.Tags == nil {
+			break
+		}
+		for _, t := range resp.Tags {
+			asgNames = append(asgNames, arn.ResourceName(*t.ResourceId))
+		}
+
+		if resp.NextToken == nil || *resp.NextToken == "" {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+
+	asgDel := deleter.AutoScalingGroupDeleter{ResourceNames: asgNames}
+	asgs, aerr := asgDel.RequestAutoScalingGroups()
+	if aerr != nil {
+		return
+	}
+
+	for _, asg := range asgs {
+		arnList = append(arnList, arn.ResourceARN(*asg.AutoScalingGroupARN))
+	}
+
+	return
+}
+
+func getRoute53ResourcesByTags(svc route53iface.Route53API, rt arn.ResourceType, rgtaTags []*rgta.TagFilter, arnList arn.ResourceARNs) {
+	if len(rgtaTags) == 0 {
+		return
+	}
+
+	// Currently only Route53 HostedZones support tagging
+	if rt != arn.Route53HostedZoneRType {
+		return
+	}
+
+	tagKeyMap := make(map[string][]string)
+	for _, tag := range rgtaTags {
+		if _, ok := tagKeyMap[*tag.Key]; !ok {
+			tagKeyMap[*tag.Key] = make([]string, 0, len(tag.Values))
+			for _, v := range tag.Values {
+				tagKeyMap[*tag.Key] = append(tagKeyMap[*tag.Key], *v)
+			}
+		}
+	}
+
+	rd := deleter.Route53HostedZoneDeleter{Client: svc}
+	hzs, rerr := rd.RequestAllRoute53HostedZones()
+	if rerr != nil || len(hzs) == 0 {
+		return
+	}
+
+	hzIDs := make(arn.ResourceNames, 0, len(hzs))
+	for _, hz := range hzs {
+		hzSplit := strings.Split(*hz.Id, "/hostedzone/")
+		if len(hzSplit) != 2 {
+			continue
+		}
+		hzIDs = append(hzIDs, arn.ResourceName(hzSplit[1]))
+	}
+
+	params := &route53.ListTagsForResourcesInput{
+		ResourceType: aws.String("hostedzone"),
+	}
+
+	size := len(hzIDs)
+	filteredIDs := make(arn.ResourceNames, 0, len(hzIDs))
+	// Can only tag hosted zones in batches of 10
+	for i := 0; i < size; i += 10 {
+		stop := i + 10
+		if size-stop < 0 {
+			stop = i + size%10
+		}
+		params.ResourceIds = hzIDs[i:stop].AWSStringSlice()
+
+		ctx := aws.BackgroundContext()
+		resp, rerr := svc.ListTagsForResourcesWithContext(ctx, params)
+		if rerr != nil {
+			fmt.Printf("{\"error\": \"%s\"}\n", rerr.Error())
+			return
+		}
+
+		for _, rts := range resp.ResourceTagSets {
+			for _, tag := range rts.Tags {
+				if vals, ok := tagKeyMap[*tag.Key]; ok {
+					// If no tag values are specified, then we want all hosted zones that
+					// match a specific key but have any value. Append all that have key
+					if vals == nil || len(vals) == 0 {
+						filteredIDs = append(filteredIDs, arn.ResourceName(*rts.ResourceId))
+						continue
+					}
+					for _, v := range vals {
+						if v == *tag.Value {
+							filteredIDs = append(filteredIDs, arn.ResourceName(*rts.ResourceId))
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+
+	for _, id := range filteredIDs {
+		hzARN := fmt.Sprintf("arn:aws:route53:::hostedzone/%s", id)
+		arnList = append(arnList, arn.ResourceARN(hzARN))
+	}
+
+	return
+}
+
+// Traverse dependency graph and request all possible ID's of resource
+// dependencies, then bucket them according to ResourceType.
+func bucketARNs(ARNs arn.ResourceARNs) map[arn.ResourceType]deleter.ResourceDeleter {
+	// All ARN's stored here. Key is some arn.*RType, value is a slice of ARN's
+	resMap := make(map[arn.ResourceType]deleter.ResourceDeleter)
+	seen := map[arn.ResourceName]struct{}{}
+
+	// Initialize with all ID's from ARN's tagged in CloudTrail logs
+	for _, a := range ARNs {
+		rt, rn := arn.MapARNToRTypeAndRName(a)
+		// Remove duplicates and nil resources
+		if _, ok := seen[rn]; ok || rt == "" || rn == "" {
+			continue
+		}
+		seen[rn] = struct{}{}
+
+		if _, ok := resMap[rt]; !ok {
+			resMap[rt] = deleter.InitResourceDeleter(rt)
+		}
+		resMap[rt].AddResourceNames(rn)
+	}
+
+	// Unless the user specifies the --all-deps flag, do not find/delete
+	// dependencies of resources
+	if delAllDeps {
+		graph.FillDependencyGraph(resMap)
+	}
+
+	return resMap
+}
+
+type delResMap struct {
+	Type     string
+	Deleters deleter.ResourceDeleter
+}
+
+func deleteARNs(ARNs arn.ResourceARNs) error {
+	// Create a slice of ARN's for every ResourceType in ARNs
+	resMap := bucketARNs(ARNs)
+	if len(resMap) == 0 {
+		return nil
+	}
+
+	// Ensure deletion order. Most resources have dependencies, so a dependency
+	// graph must be constructed and executed. See README for deletion order.
+	sorted := organizeByDelOrder(resMap)
+
+	// Delete all ARN's in a slice mapped by ResourceType. Iterate in reverse to
+	// delete all non-dependent resources first
+	cfg := &deleter.DeleteConfig{
+		IgnoreErrors: ignoreErrors,
+		DryRun:       dryRun,
+		BackoffTime:  time.Duration(viper.GetInt("grafiti.backoffTime")) * time.Millisecond,
+	}
+	for i := len(sorted) - 1; i >= 0; i-- {
+		if err := sorted[i].Deleters.DeleteResources(cfg); err != nil {
+			fmt.Printf("{\"error\": \"%s\"}\n", err.Error())
+		}
+	}
+	return nil
+}
+
+func organizeByDelOrder(resMap map[arn.ResourceType]deleter.ResourceDeleter) []delResMap {
+	sorted := make([]delResMap, 0, len(resMap))
+
+	// Append ARN's to sorted in deletion order
+	for _, rt := range DeleteOrder {
+		if dels, ok := resMap[rt]; ok {
+			sorted = append(sorted, delResMap{
+				Type:     rt.String(),
+				Deleters: dels,
+			})
+			delete(resMap, rt)
+		}
+	}
+
+	// Add the remaining ARN's
+	for rt, dels := range resMap {
+		sorted = append(sorted, delResMap{
+			Type:     rt.String(),
+			Deleters: dels,
+		})
+	}
+
+	return sorted
 }
 
 func decodeDeleteInput(decoder *json.Decoder) (*DeleteInput, bool, error) {
@@ -184,7 +460,7 @@ func decodeDeleteInput(decoder *json.Decoder) (*DeleteInput, bool, error) {
 			return &decoded, true, nil
 		}
 		if ignoreErrors {
-			fmt.Printf(`{"error": "%s"}\n`, err.Error())
+			fmt.Printf("{\"error\": \"%s\"}\n", err.Error())
 			return nil, false, nil
 		}
 		return nil, false, err

--- a/cmd/grafiti/tag_test.go
+++ b/cmd/grafiti/tag_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Set stdout to pipe and capture printed output of a Print event
-func captureRGTAStdOut(f func(rgtaiface.ResourceGroupsTaggingAPIAPI, []string, Tag) error, i rgtaiface.ResourceGroupsTaggingAPIAPI, as []string, t Tag) string {
+func captureRGTAStdOut(f func(rgtaiface.ResourceGroupsTaggingAPIAPI, arn.ResourceARNs, Tag) error, i rgtaiface.ResourceGroupsTaggingAPIAPI, as arn.ResourceARNs, t Tag) string {
 	oldStdOut := os.Stdout
 	r, w, perr := os.Pipe()
 	if perr != nil {
@@ -60,13 +60,13 @@ func TestTagARNBucket(t *testing.T) {
 
 	caseTable := []struct {
 		Resp     rgta.TagResourcesOutput
-		TestARNs []string
+		TestARNs arn.ResourceARNs
 		TestTag  Tag
 		Expected string
 	}{
 		{
 			Resp: rgta.TagResourcesOutput{},
-			TestARNs: []string{
+			TestARNs: arn.ResourceARNs{
 				"arn:aws:ec2:us-east-1:123456789101:security-group/sg-a59ca0db",
 				"arn:aws:ec2:us-east-1:123456789101:network-interface/eni-3fec2ff7",
 				"arn:aws:elasticloadbalancing:us-east-1:123456789101:loadbalancer/aws-pr-780-90123456-api-internal",
@@ -85,7 +85,7 @@ func TestTagARNBucket(t *testing.T) {
 				`"Tags":{"TaggedAt":"2017-05-31"}}`, "\n"),
 		}, {
 			Resp:     rgta.TagResourcesOutput{},
-			TestARNs: []string{},
+			TestARNs: arn.ResourceARNs{},
 			TestTag:  Tag{"TaggedAt", "2017-05-31"},
 			Expected: `{"ResourceARNList":[],"Tags":{"TaggedAt":"2017-05-31"}}` + "\n",
 		},
@@ -104,7 +104,7 @@ func TestTagARNBucket(t *testing.T) {
 }
 
 // Set stdout to pipe and capture printed output of a Print event
-func captureRGTAUnsupportedStdOut(f func(interface{}, string, string, Tags), i interface{}, rt, rn string, t Tags) string {
+func captureRGTAUnsupportedStdOut(f func(interface{}, arn.ResourceType, arn.ResourceName, Tags), i interface{}, rt arn.ResourceType, rn arn.ResourceName, t Tags) string {
 	oldStdOut := os.Stdout
 	r, w, perr := os.Pipe()
 	if perr != nil {
@@ -142,7 +142,7 @@ func TestTagAutoScalingResource(t *testing.T) {
 
 	caseTable := []struct {
 		Resp      autoscaling.CreateOrUpdateTagsOutput
-		InputName string
+		InputName arn.ResourceName
 		InputTags Tags
 		Expected  string
 	}{
@@ -161,8 +161,8 @@ func TestTagAutoScalingResource(t *testing.T) {
 		},
 	}
 
-	f := func(v interface{}, rt, arn string, t Tags) {
-		tagAutoScalingResource(v.(autoscalingiface.AutoScalingAPI), rt, arn, t)
+	f := func(v interface{}, rt arn.ResourceType, rn arn.ResourceName, t Tags) {
+		tagAutoScalingResource(v.(autoscalingiface.AutoScalingAPI), rt, rn, t)
 	}
 
 	for _, c := range caseTable {
@@ -191,7 +191,7 @@ func TestTagRoute53Resource(t *testing.T) {
 
 	caseTable := []struct {
 		Resp      route53.ChangeTagsForResourceOutput
-		InputName string
+		InputName arn.ResourceName
 		InputTags Tags
 		Expected  string
 	}{
@@ -210,8 +210,8 @@ func TestTagRoute53Resource(t *testing.T) {
 		},
 	}
 
-	f := func(v interface{}, rt, arn string, t Tags) {
-		tagRoute53Resource(v.(route53iface.Route53API), rt, arn, t)
+	f := func(v interface{}, rt arn.ResourceType, rn arn.ResourceName, t Tags) {
+		tagRoute53Resource(v.(route53iface.Route53API), rt, rn, t)
 	}
 
 	for _, c := range caseTable {

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,7 @@
 [grafiti]
 resourceType = "AWS::EC2::Instance"
 hours = -8
+backoffTime = 1000 # 1 second in milliseconds
 az = "us-east-1"
 includeEvent = false
 tagPatterns = [

--- a/deleter/route53.go
+++ b/deleter/route53.go
@@ -1,0 +1,287 @@
+package deleter
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/aws/aws-sdk-go/service/route53/route53iface"
+	"github.com/coreos/grafiti/arn"
+)
+
+// Route53HostedZoneDeleter represents an AWS route53 hosted zone
+type Route53HostedZoneDeleter struct {
+	Client        route53iface.Route53API
+	ResourceType  arn.ResourceType
+	ResourceNames arn.ResourceNames
+}
+
+func (rd *Route53HostedZoneDeleter) String() string {
+	return fmt.Sprintf(`{"Type": "%s", "Names": %v}`, rd.ResourceType, rd.ResourceNames)
+}
+
+// AddResourceNames adds route53 hosted zone names to Names
+func (rd *Route53HostedZoneDeleter) AddResourceNames(ns ...arn.ResourceName) {
+	rd.ResourceNames = append(rd.ResourceNames, ns...)
+}
+
+// DeleteResources deletes hosted zones from AWS
+// NOTE: must delete all non-default resource record sets before deleting a
+// hosted zone. Will receive HostedZoneNotEmpty otherwise
+func (rd *Route53HostedZoneDeleter) DeleteResources(cfg *DeleteConfig) error {
+	if len(rd.ResourceNames) == 0 {
+		return nil
+	}
+
+	rrsDeleter := Route53ResourceRecordSetDeleter{ResourceNames: rd.ResourceNames}
+	if rerr := rrsDeleter.DeleteResources(cfg); rerr != nil {
+		return rerr
+	}
+
+	fmtStr := "Deleted Route53 HostedZone"
+	if cfg.DryRun {
+		for _, id := range rd.ResourceNames {
+			fmt.Println(drStr, fmtStr, id)
+		}
+		return nil
+	}
+
+	if rd.Client == nil {
+		rd.Client = route53.New(setUpAWSSession())
+	}
+
+	var params *route53.DeleteHostedZoneInput
+	for _, n := range rd.ResourceNames {
+		params = &route53.DeleteHostedZoneInput{
+			Id: n.AWSString(),
+		}
+
+		ctx := aws.BackgroundContext()
+		_, err := rd.Client.DeleteHostedZoneWithContext(ctx, params)
+		if err != nil {
+			if cfg.IgnoreErrors {
+				fmt.Printf("{\"error\": \"%s\"}\n", err.Error())
+				continue
+			}
+			return err
+		}
+
+		fmt.Println(fmtStr, n)
+		// Prevent throttling
+		time.Sleep(cfg.BackoffTime)
+	}
+	return nil
+}
+
+// DeletePrivateRoute53HostedZones deletes only private hosted zones
+func (rd *Route53HostedZoneDeleter) DeletePrivateRoute53HostedZones(cfg *DeleteConfig) error {
+	hzs, err := rd.RequestRoute53HostedZones()
+	if err != nil || len(hzs) == 0 {
+		return nil
+	}
+
+	privIDs := make(arn.ResourceNames, 0)
+	for _, hz := range hzs {
+		if *hz.Config.PrivateZone {
+			hzSplit := strings.Split(*hz.Id, "/hostedzone/")
+			if len(hzSplit) != 2 {
+				continue
+			}
+			privIDs = append(privIDs, arn.ResourceName(hzSplit[1]))
+		}
+	}
+
+	rd.ResourceNames = privIDs
+
+	return rd.DeleteResources(cfg)
+}
+
+// RequestRoute53HostedZones requests resources from the AWS API and returns route53
+// hosted zones by names
+func (rd *Route53HostedZoneDeleter) RequestRoute53HostedZones() ([]*route53.HostedZone, error) {
+	if len(rd.ResourceNames) == 0 {
+		return nil, nil
+	}
+
+	// Only way to filter is iteratively (no query parameters)
+	want := map[arn.ResourceName]struct{}{}
+	for _, id := range rd.ResourceNames {
+		if _, ok := want["/hostedzone/"+id]; !ok {
+			want["/hostedzone/"+id] = struct{}{}
+		}
+	}
+
+	wantedHZs := make([]*route53.HostedZone, 0)
+	hzs, err := rd.RequestAllRoute53HostedZones()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, hz := range hzs {
+		if _, ok := want[arn.ResourceName(*hz.Id)]; ok {
+			wantedHZs = append(wantedHZs, hz)
+		}
+	}
+
+	return wantedHZs, nil
+}
+
+// RequestAllRoute53HostedZones retrieves a list of all hosted zones
+func (rd *Route53HostedZoneDeleter) RequestAllRoute53HostedZones() ([]*route53.HostedZone, error) {
+	hzs := make([]*route53.HostedZone, 0)
+	params := &route53.ListHostedZonesInput{
+		MaxItems: aws.String("100"),
+	}
+
+	if rd.Client == nil {
+		rd.Client = route53.New(setUpAWSSession())
+	}
+
+	for {
+		ctx := aws.BackgroundContext()
+		resp, err := rd.Client.ListHostedZonesWithContext(ctx, params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, hz := range resp.HostedZones {
+			hzs = append(hzs, hz)
+		}
+
+		if resp.IsTruncated == nil || !*resp.IsTruncated {
+			break
+		}
+
+		params.Marker = resp.NextMarker
+	}
+
+	return hzs, nil
+}
+
+// Route53ResourceRecordSetDeleter represents an AWS route53 resource record set
+type Route53ResourceRecordSetDeleter struct {
+	Client        route53iface.Route53API
+	ResourceType  arn.ResourceType
+	ResourceNames arn.ResourceNames
+}
+
+func (rd *Route53ResourceRecordSetDeleter) String() string {
+	return fmt.Sprintf(`{"Type": "%s", "Names": %v}`, rd.ResourceType, rd.ResourceNames)
+}
+
+// AddResourceNames adds route53 resource record set names to Names
+func (rd *Route53ResourceRecordSetDeleter) AddResourceNames(ns ...arn.ResourceName) {
+	rd.ResourceNames = append(rd.ResourceNames, ns...)
+}
+
+// DeleteResources deletes route53 resource record sets from AWS
+func (rd *Route53ResourceRecordSetDeleter) DeleteResources(cfg *DeleteConfig) error {
+	if len(rd.ResourceNames) == 0 {
+		return nil
+	}
+
+	rrsMap, rerr := rd.RequestRoute53ResourceRecordSets()
+	if rerr != nil || len(rrsMap) == 0 {
+		return rerr
+	}
+
+	fmtStr := "Deleted Route53 ResourceRecordSet"
+	if cfg.DryRun {
+		for hz, rrss := range rrsMap {
+			for _, rrs := range rrss {
+				fmt.Printf("%s %s %s (HZ %s)\n", drStr, fmtStr, rrs, hz)
+			}
+		}
+		return nil
+	}
+
+	if rd.Client == nil {
+		rd.Client = route53.New(setUpAWSSession())
+	}
+
+	var changes []*route53.Change
+	for hz, rrss := range rrsMap {
+		changes = make([]*route53.Change, 0, len(rrss))
+		for _, rrs := range rrss {
+			changes = append(changes, &route53.Change{
+				Action:            aws.String(route53.ChangeActionDelete),
+				ResourceRecordSet: rrs,
+			})
+		}
+
+		params := &route53.ChangeResourceRecordSetsInput{
+			ChangeBatch:  &route53.ChangeBatch{Changes: changes},
+			HostedZoneId: hz.AWSString(),
+		}
+
+		ctx := aws.BackgroundContext()
+		_, err := rd.Client.ChangeResourceRecordSetsWithContext(ctx, params)
+		if err != nil {
+			if cfg.IgnoreErrors {
+				fmt.Printf("{\"error\": \"%s\"}\n", err.Error())
+				return nil
+			}
+			return err
+		}
+
+		for _, rrs := range rrss {
+			fmt.Printf("%s %s (HZ %s)\n", fmtStr, *rrs.Name, hz)
+		}
+		// Prevent throttling
+		time.Sleep(cfg.BackoffTime)
+	}
+
+	return nil
+}
+
+// RequestRoute53ResourceRecordSets requests route53 resource record sets by
+// hosted zone names from the AWS API and returns a map of hosted zones to
+// resource record sets
+func (rd *Route53ResourceRecordSetDeleter) RequestRoute53ResourceRecordSets() (map[arn.ResourceName][]*route53.ResourceRecordSet, error) {
+	if len(rd.ResourceNames) == 0 {
+		return nil, nil
+	}
+
+	rrsMap := make(map[arn.ResourceName][]*route53.ResourceRecordSet)
+	var params *route53.ListResourceRecordSetsInput
+
+	if rd.Client == nil {
+		rd.Client = route53.New(setUpAWSSession())
+	}
+
+	for _, hz := range rd.ResourceNames {
+		params = &route53.ListResourceRecordSetsInput{
+			HostedZoneId: hz.AWSString(),
+			MaxItems:     aws.String("100"),
+		}
+
+		for {
+			ctx := aws.BackgroundContext()
+			resp, err := rd.Client.ListResourceRecordSetsWithContext(ctx, params)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, rrs := range resp.ResourceRecordSets {
+				// Cannot delete NS/SOA type record sets
+				if *rrs.Type == "NS" || *rrs.Type == "SOA" {
+					continue
+				}
+
+				rrsMap[hz] = append(rrsMap[hz], rrs)
+			}
+
+			if resp.IsTruncated == nil || !*resp.IsTruncated {
+				break
+			}
+
+			params.StartRecordIdentifier = resp.NextRecordIdentifier
+			params.StartRecordType = resp.NextRecordType
+			params.StartRecordName = resp.NextRecordName
+		}
+	}
+
+	return rrsMap, nil
+}


### PR DESCRIPTION
arn/: Removed untaggable resources (regardless of rgta support) from RGTAUnsupportedResourceTypes, as they cannot be queried by tag

cmd/grafiti/: Added autoscaling and route53 tag query functions, refactored to streamline deletion with this broader range of resource support, and implemented a deletion order based on AWS-enforced relationships

deleter/: implemeneted route53 hosted zone and resource record set deleters/requesters

Fixes #10 