### PR TITLE
Structured deletion logs

### DIFF
--- a/arn/arn.go
+++ b/arn/arn.go
@@ -250,6 +250,8 @@ const (
 	Route53ChangeRType = "AWS::Route53::Change"
 	// Route53HostedZoneRType is an AWS ResourceType enum value
 	Route53HostedZoneRType = "AWS::Route53::HostedZone"
+	// Route53ResourceRecordSetRType is an AWS ResourceType enum value
+	Route53ResourceRecordSetRType = "AWS::Route53::ResourceRecordSet"
 	// S3BucketRType is an AWS ResourceType enum value
 	S3BucketRType = "AWS::S3::Bucket"
 )

--- a/deleter/autoscaling.go
+++ b/deleter/autoscaling.go
@@ -54,8 +54,8 @@ func (rd *AutoScalingGroupDeleter) DeleteResources(cfg *DeleteConfig) error {
 		ctx := aws.BackgroundContext()
 		_, err := rd.Client.DeleteAutoScalingGroupWithContext(ctx, params)
 		if err != nil {
+			cfg.logDeleteError(arn.AutoScalingGroupRType, n, err)
 			if cfg.IgnoreErrors {
-				fmt.Printf("{\"error\": \"%s\"}\n", err.Error())
 				continue
 			}
 			return err
@@ -150,8 +150,8 @@ func (rd *AutoScalingLaunchConfigurationDeleter) DeleteResources(cfg *DeleteConf
 		ctx := aws.BackgroundContext()
 		_, err := rd.Client.DeleteLaunchConfigurationWithContext(ctx, params)
 		if err != nil {
+			cfg.logDeleteError(arn.AutoScalingLaunchConfigurationRType, n, err)
 			if cfg.IgnoreErrors {
-				fmt.Printf("{\"error\": \"%s\"}\n", err.Error())
 				continue
 			}
 			return err

--- a/deleter/deleter.go
+++ b/deleter/deleter.go
@@ -1,9 +1,12 @@
 package deleter
 
 import (
+	"os"
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/coreos/grafiti/arn"
 	"github.com/spf13/viper"
@@ -24,6 +27,63 @@ type DeleteConfig struct {
 	DryRun       bool
 	IgnoreErrors bool
 	BackoffTime  time.Duration
+	Logger       logrus.FieldLogger
+}
+
+// InitRequestLogger creates a logrus.FieldLogger that logs to a file at path,
+// or os.Stderr if an error occurs opening the file
+func InitRequestLogger(path string) logrus.FieldLogger {
+	logger := &logrus.Logger{
+		Out:       os.Stderr,
+		Formatter: &logrus.JSONFormatter{},
+		Level:     logrus.InfoLevel,
+	}
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0664)
+	if err == nil {
+		logger.Out = f
+	} else {
+		logger.Infof("Failed to open file %s for logging, using stderr instead", path)
+	}
+
+	return logger
+}
+
+// LogEntry maps potential log entry fields to a Go struct. Add fields here when
+// creating fields in ResourceDeleter.DeleteResources implementations
+type LogEntry struct {
+	ResourceType       arn.ResourceType `json:"resource_type"`
+	ResourceName       arn.ResourceName `json:"resource_name"`
+	AWSErrorCode       string           `json:"aws_err_code,omitempty"`
+	AWSErrorMsg        string           `json:"aws_err_msg,omitempty"`
+	ErrMsg             string           `json:"err_msg,omitempty"`
+	ParentResourceType arn.ResourceType `json:"parent_resource_type,omitempty"`
+	ParentResourceName arn.ResourceName `json:"parent_resource_name,omitempty"`
+}
+
+// Log deletion errors to a DeleteConfig.Logger
+func (c *DeleteConfig) logDeleteError(rt arn.ResourceType, rn arn.ResourceName, err error, fs ...logrus.Fields) {
+	fields := logrus.Fields{
+		"resource_type": rt,
+		"resource_name": rn.String(),
+	}
+
+	aerr, ok := err.(awserr.Error)
+	if ok {
+		fields["aws_err_code"] = aerr.Code()
+		fields["aws_err_msg"] = aerr.Message()
+	} else {
+		fields["err_msg"] = err.Error()
+	}
+
+	// Allow overwriting old fields or adding extra fields if desired
+	if len(fs) > 0 {
+		for fk, fv := range fs[0] {
+			fields[fk] = fv
+		}
+	}
+
+	c.Logger.WithFields(fields).Info("Failed to delete resource")
 }
 
 // A ResourceDeleter is any type that can delete itself from AWS and describe


### PR DESCRIPTION
deleter/: all errors resulting from a failed resource deletion are logged using `logrus`. Log entries are JSON objects consisting of resource type, name, error code, message. Certain resources can add fields to log entries as needed.

cmd/grafiti/: the log file is parsed after a deletion cycle and each entry is printed in report format.

Fixes #11 