### PR TITLE
Slice update bug fix and naming updates

### DIFF
--- a/cmd/grafiti/filter.go
+++ b/cmd/grafiti/filter.go
@@ -121,7 +121,7 @@ func initIgnoreTagMap(svc rgtaiface.ResourceGroupsTaggingAPIAPI, r io.Reader) (m
 	// Tag file decoder
 	dec := json.NewDecoder(r)
 	// Collection of ARN's of resources to ignore
-	arns := make([]arn.ResourceARN, 0)
+	arns := make(arn.ResourceARNs, 0)
 	// Map of resources ARN's to ignore
 	itMap := map[arn.ResourceARN]struct{}{}
 
@@ -137,7 +137,7 @@ func initIgnoreTagMap(svc rgtaiface.ResourceGroupsTaggingAPIAPI, r io.Reader) (m
 			continue
 		}
 
-		getARNsForResource(svc, t.TagFilters, arns)
+		getARNsForResource(svc, t.TagFilters, &arns)
 	}
 
 	for _, arn := range arns {

--- a/deleter/autoscaling.go
+++ b/deleter/autoscaling.go
@@ -87,8 +87,9 @@ func (rd *AutoScalingGroupDeleter) RequestAutoScalingGroups() ([]*autoscaling.Gr
 	asgs := make([]*autoscaling.Group, 0)
 
 	for {
-		req, resp := rd.Client.DescribeAutoScalingGroupsRequest(params)
-		if err := req.Send(); err != nil {
+		ctx := aws.BackgroundContext()
+		resp, err := rd.Client.DescribeAutoScalingGroupsWithContext(ctx, params)
+		if err != nil {
 			return nil, err
 		}
 
@@ -181,8 +182,9 @@ func (rd *AutoScalingLaunchConfigurationDeleter) RequestAutoScalingLaunchConfigu
 	lcs := make([]*autoscaling.LaunchConfiguration, 0)
 
 	for {
-		req, resp := rd.Client.DescribeLaunchConfigurationsRequest(params)
-		if err := req.Send(); err != nil {
+		ctx := aws.BackgroundContext()
+		resp, err := rd.Client.DescribeLaunchConfigurationsWithContext(ctx, params)
+		if err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
cmd/grafiti/: updated `DeleteInput` -> `TagFileInput` to generalize the type for both filter and delete step usage, updated AWS API calls to use context, and updated ARN slice input parameter to take a pointer in order to update caller slices correctly.

deleter/: updated AWS API calls to use context