### PR TITLE
Timed ARN bucket ejection in tag step

### DIFF
--- a/cmd/grafiti/main.go
+++ b/cmd/grafiti/main.go
@@ -53,6 +53,9 @@ func initConfig() {
 		viper.SetConfigFile(cfgFile)
 	}
 
+	// Default bucket ejection time: 10 minutes in seconds
+	viper.SetDefault("grafiti.bucketEjectLimitSeconds", 300)
+
 	viper.SetConfigName(".grafiti") // name of config file (without extension)
 	viper.AddConfigPath("$HOME")    // adding home directory as first search path
 	viper.AutomaticEnv()            // read in environment variables that match

--- a/config.toml
+++ b/config.toml
@@ -5,6 +5,7 @@ startHour = -8
 # endTimeStamp = "2017-06-14T08:00:00Z" # RFC-3339 format in UTC
 # startTimeStamp = "2017-06-13T00:00:00Z"
 backoffTime = 1000 # 1 second in milliseconds
+# bucketEjectLimitSeconds = 300 # Number of seconds to wait to tag ARN bucket (default 10 min)
 region = "us-west-2"
 includeEvent = false
 tagPatterns = [

--- a/testdata/config/test-config.toml
+++ b/testdata/config/test-config.toml
@@ -5,6 +5,7 @@ startHour = -8
 # endTimeStamp = "2017-06-14T08:00:00Z" # RFC-3339 format in UTC
 # startTimeStamp = "2017-06-13T00:00:00Z"
 backoffTime = 1000 # 1 second in milliseconds
+# bucketEjectLimitSeconds = 300 # Number of seconds to wait to tag ARN bucket (default 10 min)
 region = "us-west-2"
 includeEvent = false
 tagPatterns = [


### PR DESCRIPTION
cmd/grafiti/: user can specify how long to wait until buckets of ARNs to tag are tagged, which is useful in daemon mode. The timer resets after ejection. Default 10 minutes

*: config files updated to include `bucketEjectLimitSeconds` field example

Fixes #6 