### PR TITLE
Configurable maximum number of API requests

### DIFF
--- a/cmd/grafiti/main.go
+++ b/cmd/grafiti/main.go
@@ -77,6 +77,8 @@ func initConfig() {
 
 	// Default bucket ejection time: 10 minutes in seconds
 	viper.SetDefault("bucketEjectLimitSeconds", 300)
+	// Default number of delete request retries
+	viper.SetDefault("maxNumRequestRetries", 8)
 
 	// If a config file is found, read in its data
 	if err := viper.ReadInConfig(); err == nil {

--- a/cmd/grafiti/parse.go
+++ b/cmd/grafiti/parse.go
@@ -184,7 +184,7 @@ func parseFromCloudTrail(svc cloudtrailiface.CloudTrailAPI) error {
 		return nil
 	}
 
-	// Create LookupEvents for all grafiti.resourceTypes. If none are specified,
+	// Create LookupEvents for all resourceTypes. If none are specified,
 	// look up all events for all resourceTypes
 	rts := viper.GetStringSlice("resourceTypes")
 	var attrs []*cloudtrail.LookupAttribute

--- a/config.toml
+++ b/config.toml
@@ -1,10 +1,10 @@
-[grafiti]
 resourceTypes = ["AWS::EC2::Instance"]
 endHour = 0
 startHour = -8
 # endTimeStamp = "2017-06-14T08:00:00Z" # RFC-3339 format in UTC
 # startTimeStamp = "2017-06-13T00:00:00Z"
 region = "us-west-2"
+maxNumRequestRetries = 8
 includeEvent = false
 tagPatterns = [
   "{CreatedBy: .userIdentity.arn}",

--- a/deleter/deleter.go
+++ b/deleter/deleter.go
@@ -18,10 +18,11 @@ import (
 const drStr = "(dry-run)"
 
 func setUpAWSSession() *session.Session {
+	maxRetries := viper.GetInt("maxNumRequestRetries")
 	return session.Must(session.NewSession(
 		&aws.Config{
 			Region:  aws.String(viper.GetString("region")),
-			Retryer: retryer.DeleteRetryer{NumMaxRetries: 11},
+			Retryer: retryer.DeleteRetryer{NumMaxRetries: maxRetries},
 		},
 	))
 }

--- a/testdata/config/empty-test-config.toml
+++ b/testdata/config/empty-test-config.toml
@@ -1,2 +1,1 @@
-[grafiti]
 region = "us-west-2"

--- a/testdata/config/test-config.toml
+++ b/testdata/config/test-config.toml
@@ -1,10 +1,10 @@
-[grafiti]
 resourceTypes = ["AWS::EC2::Instance"]
 endHour = 0
 startHour = -8
 # endTimeStamp = "2017-06-14T08:00:00Z" # RFC-3339 format in UTC
 # startTimeStamp = "2017-06-13T00:00:00Z"
 region = "us-west-2"
+maxNumRequestRetries = 8
 includeEvent = false
 tagPatterns = [
   # "{CreatedBy: .userIdentity.arn}",


### PR DESCRIPTION
*: configurable number of retries on delete requests

deleter/,cmd/grafiti/: defaults and getters for 'maxNumRequestRetries' in config files

config.toml,/testdata/config/: config file updates to reflect above additions