### PR TITLE
Removed 'grafiti' cfg namespace and added optional env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,18 @@ filterPatterns = [
  * `tagPatterns` - should use `jq` syntax to generate `{tagKey: tagValue}` objects from output from `grafiti parse`. The results will be included in the `Tags` field of the tagging output.
  * `filterPatterns` - will filter output of `grafiti parse` based on `jq` syntax matches.
 
+### Environment variables
+
+In addition to, or in lieu of, a config file, grafiti can be configured with the following environment variables:
+
+ * `AWS_REGION` corresponds to the `region` config file field.
+ * `GRF_START_HOUR` corresponds to the `startHour` config file field.
+ * `GRF_END_HOUR` corresponds to the `endHour` config file field.
+ * `GRF_START_TIMESTAMP` corresponds to the `startTimeStamp` config file field.
+ * `GRF_END_TIMESTAMP` corresponds to the `endTimeStamp` config file field.
+ * `GRF_INCLUDE_EVENT` corresponds to the `includeEvent` config file field.
+
+If one of the above variables is set, its' data will be used as a default value. That means that the only circumstance in which its' value will be used is when no corresponding config file field is set, and, by extension, no config file is provided. Setting these variables allows you to avoid using a config file.
 
 ### A note on AWS resource deletion order
 AWS resources have (potentially many) dependencies that must be explicitly detached/removed/deleted before deleting a top-level resource (ex. a VPC). Therefore a deletion order must be enforced. This order is universal for all AWS resources and is not use-case-specific, because deletion actions will only run if a resource with a specific tag, or one of it's dependencies, is detected.

--- a/arn/arn.go
+++ b/arn/arn.go
@@ -357,7 +357,7 @@ func getAutoScalingGroup(rn ResourceName) (*autoscaling.Group, error) {
 
 	svc := autoscaling.New(session.Must(session.NewSession(
 		&aws.Config{
-			Region: aws.String(viper.GetString("grafiti.region")),
+			Region: aws.String(viper.GetString("region")),
 		},
 	)))
 	params := &autoscaling.DescribeAutoScalingGroupsInput{

--- a/cmd/grafiti/delete.go
+++ b/cmd/grafiti/delete.go
@@ -124,7 +124,7 @@ func deleteFromTags(reader io.Reader) error {
 
 	svc := rgta.New(session.Must(session.NewSession(
 		&aws.Config{
-			Region: aws.String(viper.GetString("grafiti.region")),
+			Region: aws.String(viper.GetString("region")),
 		},
 	)))
 
@@ -169,7 +169,7 @@ func getARNsForResource(svc rgtaiface.ResourceGroupsTaggingAPIAPI, tags []*rgta.
 	}
 
 	// If available, get all resourceTypes from config file
-	rts := viper.GetStringSlice("grafiti.resourceTypes")
+	rts := viper.GetStringSlice("resourceTypes")
 	if len(rts) != 0 {
 		frts := make([]*string, 0, len(rts))
 		for _, t := range rts {
@@ -214,7 +214,7 @@ func getARNsForResource(svc rgtaiface.ResourceGroupsTaggingAPIAPI, tags []*rgta.
 func getARNsForUnsupportedResource(rt arn.ResourceType, tags []*rgta.TagFilter, arnList arn.ResourceARNs) arn.ResourceARNs {
 	sess := session.Must(session.NewSession(
 		&aws.Config{
-			Region: aws.String(viper.GetString("grafiti.region")),
+			Region: aws.String(viper.GetString("region")),
 		},
 	))
 

--- a/cmd/grafiti/filter.go
+++ b/cmd/grafiti/filter.go
@@ -48,7 +48,7 @@ func runFilterCommand(cmd *cobra.Command, args []string) error {
 
 	svc := rgta.New(session.Must(session.NewSession(
 		&aws.Config{
-			Region: aws.String(viper.GetString("grafiti.region")),
+			Region: aws.String(viper.GetString("region")),
 		},
 	)))
 

--- a/cmd/grafiti/filter_test.go
+++ b/cmd/grafiti/filter_test.go
@@ -56,8 +56,8 @@ func TestFilter(t *testing.T) {
 	wd, _ := os.Getwd()
 	dataDir := wd + "/../../testdata"
 
-	viper.Set("grafiti.tagPatterns", []string{})
-	viper.Set("grafiti.resourceTypes", []string{})
+	viper.Set("tagPatterns", []string{})
+	viper.Set("resourceTypes", []string{})
 
 	cases := []struct {
 		InputFilePath    string

--- a/cmd/grafiti/parse.go
+++ b/cmd/grafiti/parse.go
@@ -74,7 +74,7 @@ func runParseCommand(cmd *cobra.Command, args []string) error {
 
 	sess := session.Must(session.NewSession(
 		&aws.Config{
-			Region: aws.String(viper.GetString("grafiti.region")),
+			Region: aws.String(viper.GetString("region")),
 		},
 	))
 	if err := parseFromCloudTrail(cloudtrail.New(sess)); err != nil {
@@ -137,10 +137,10 @@ type NotTaggedFilter struct {
 func parseFromCloudTrail(svc cloudtrailiface.CloudTrailAPI) error {
 	var start, end *time.Time
 	// Check if timestamps or hours exist
-	if viper.IsSet("grafiti.startTimeStamp") && viper.IsSet("grafiti.endTimeStamp") {
-		start, end = calcTimeWindowFromTimeStamp(viper.GetString("grafiti.startTimeStamp"), viper.GetString("grafiti.endTimeStamp"))
-	} else if viper.IsSet("grafiti.startHour") && viper.IsSet("grafiti.endHour") {
-		start, end = calcTimeWindowFromHourRange(viper.GetInt("grafiti.startHour"), viper.GetInt("grafiti.endHour"))
+	if viper.IsSet("startTimeStamp") && viper.IsSet("endTimeStamp") {
+		start, end = calcTimeWindowFromTimeStamp(viper.GetString("startTimeStamp"), viper.GetString("endTimeStamp"))
+	} else if viper.IsSet("startHour") && viper.IsSet("endHour") {
+		start, end = calcTimeWindowFromHourRange(viper.GetInt("startHour"), viper.GetInt("endHour"))
 	}
 	if start == nil || end == nil {
 		return nil
@@ -148,7 +148,7 @@ func parseFromCloudTrail(svc cloudtrailiface.CloudTrailAPI) error {
 
 	// Create LookupEvents for all grafiti.resourceTypes. If none are specified,
 	// look up all events for all resourceTypes
-	rts := viper.GetStringSlice("grafiti.resourceTypes")
+	rts := viper.GetStringSlice("resourceTypes")
 	var attrs []*cloudtrail.LookupAttribute
 	if len(rts) == 0 {
 		attrs = []*cloudtrail.LookupAttribute{nil}
@@ -273,7 +273,7 @@ func printEvent(event *cloudtrail.Event, parsedEvent gjson.Result) {
 }
 
 func parseDataFromEvent(rt arn.ResourceType, rn arn.ResourceName, parsedEvent gjson.Result, event *cloudtrail.Event) string {
-	includeEvent := viper.GetBool("grafiti.includeEvent")
+	includeEvent := viper.GetBool("includeEvent")
 	ARN := arn.MapResourceTypeToARN(rt, rn, parsedEvent)
 	if ARN == "" {
 		return ""
@@ -302,7 +302,7 @@ func parseDataFromEvent(rt arn.ResourceType, rn arn.ResourceName, parsedEvent gj
 }
 
 func matchFilter(output []byte) bool {
-	for _, f := range viper.GetStringSlice("grafiti.filterPatterns") {
+	for _, f := range viper.GetStringSlice("filterPatterns") {
 		results, err := jq.Eval(string(output), f)
 		if err != nil || len(results) == 0 {
 			return false
@@ -317,7 +317,7 @@ func matchFilter(output []byte) bool {
 }
 
 func getTags(rawEvent string) map[string]string {
-	tagPatterns := viper.GetStringSlice("grafiti.tagPatterns")
+	tagPatterns := viper.GetStringSlice("tagPatterns")
 	if len(tagPatterns) == 0 {
 		return map[string]string{}
 	}

--- a/cmd/grafiti/parse_test.go
+++ b/cmd/grafiti/parse_test.go
@@ -148,7 +148,7 @@ func TestParseCloudTrailEvent(t *testing.T) {
 
 	var event []byte
 	for i, c := range cases {
-		viper.Set("grafiti.tagPatterns", c.InputPatterns)
+		viper.Set("tagPatterns", c.InputPatterns)
 
 		// Get desired output of parseRawCloudTrailEvent from file
 		want, err := ioutil.ReadFile(c.ExpectedFile)
@@ -216,7 +216,7 @@ func TestPrintCloudTrailEvents(t *testing.T) {
 
 	var ctJSON string
 	for i, c := range cases {
-		viper.Set("grafiti.tagPatterns", c.InputPatterns)
+		viper.Set("tagPatterns", c.InputPatterns)
 
 		f := func(v interface{}) {
 			printEvents(v.([]*cloudtrail.Event))
@@ -245,7 +245,7 @@ func TestGetTags(t *testing.T) {
 		"{ExpiresAt: (1497253282) | strftime(\"%Y-%m-%d\")}",
 	}
 
-	viper.Set("grafiti.tagPatterns", tags)
+	viper.Set("tagPatterns", tags)
 
 	mockTags := map[string]string{
 		"CreatedBy": "arn:aws:iam::123456789101:user/test-user",
@@ -298,7 +298,7 @@ func TestMatchFilter(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		viper.Set("grafiti.filterPatterns", c.InputFilters)
+		viper.Set("filterPatterns", c.InputFilters)
 		if matchFilter([]byte(c.InputObject)) != c.ExpectedMatch {
 			t.Errorf("matchFilter case %d failed\nFilter did not match output:\n%s\n", i+1, c.InputObject)
 		}

--- a/cmd/grafiti/tag.go
+++ b/cmd/grafiti/tag.go
@@ -62,7 +62,7 @@ type TagInput struct {
 }
 
 func shouldEject(ejectSize, setSize int, createdAt time.Time) bool {
-	limitInt := viper.GetInt("grafiti.bucketEjectLimitSeconds")
+	limitInt := viper.GetInt("bucketEjectLimitSeconds")
 	limit := time.Duration(limitInt) * time.Second
 
 	ejectTime := time.Time(createdAt.Add(limit))
@@ -256,7 +256,7 @@ func tagFromStdIn() error {
 func tag(reader io.Reader) error {
 	svc := rgta.New(session.Must(session.NewSession(
 		&aws.Config{
-			Region: aws.String(viper.GetString("grafiti.region")),
+			Region: aws.String(viper.GetString("region")),
 		},
 	)))
 	dec := json.NewDecoder(reader)
@@ -315,7 +315,7 @@ func tag(reader io.Reader) error {
 func tagUnsupportedResourceType(rt arn.ResourceType, nameSet ResourceNameSet) error {
 	sess := session.Must(session.NewSession(
 		&aws.Config{
-			Region: aws.String(viper.GetString("grafiti.region")),
+			Region: aws.String(viper.GetString("region")),
 		},
 	))
 

--- a/deleter/deleter.go
+++ b/deleter/deleter.go
@@ -20,7 +20,7 @@ const drStr = "(dry-run)"
 func setUpAWSSession() *session.Session {
 	return session.Must(session.NewSession(
 		&aws.Config{
-			Region:  aws.String(viper.GetString("grafiti.region")),
+			Region:  aws.String(viper.GetString("region")),
 			Retryer: retryer.DeleteRetryer{NumMaxRetries: 11},
 		},
 	))


### PR DESCRIPTION
cmd/grafiti/: grafiti can now use environmental variables instead of a config file. As of now, only `AWS_REGION` for the `region` config file key is supported. This feature is especially useful for `grafiti delete`, which can function using only `region`.

*: removed grafiti namespace from all config field getters due to a [bug in viper](https://github.com/spf13/viper/issues/309) that prevents setting of defaults if field key is not the parent key, i.e. default of `grafiti.region` can't be set but `region` can be.

Fixes #76, #80