### PR TITLE
Parse CloudTrail data from stdin

### DIFF
--- a/deleter/route53.go
+++ b/deleter/route53.go
@@ -222,6 +222,13 @@ func (rd *Route53ResourceRecordSetDeleter) DeleteResources(cfg *DeleteConfig) er
 		params  *route53.ChangeResourceRecordSetsInput
 	)
 	for hz, rrss := range rrsMap {
+		if cfg.DryRun {
+			for _, rrs := range rrss {
+				fmt.Printf("%s %s %s (HZ %s)\n", drStr, fmtStr, *rrs.Name, hz)
+			}
+			continue
+		}
+
 		changes = make([]*route53.Change, 0, len(rrss))
 		for _, rrs := range rrss {
 			if cfg.DryRun {


### PR DESCRIPTION
cmd/grafiti/: parse cloudtrail data from stdin, added event handlers to `rawEventMap`

deleter/: route53 dry run breaks loop correctly

Fixes #44 