### PR TITLE
Audit logging to an S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ endTimeStamp = "2017-06-14T01:01:01Z"
 startTimeStamp = "2017-06-13T01:01:01Z"
 region = "us-east-1"
 maxNumRequestRetries = 11
+logS3BucketKey = "grafiti-test-bucket"
 includeEvent = false
 tagPatterns = [
   "{CreatedBy: .userIdentity.arn}"
@@ -119,6 +120,7 @@ filterPatterns = [
  * `region` - The AWS region to query.
  * `maxNumRequestRetries` = The maximum number of retries the delete request retryer should attempt. Defaults to 8.
  * `includeEvent` - Setting `true` will include the raw CloudEvent in the tagging output (this is useful for finding attributes to filter on).
+ * `logS3BucketName` - Name of an S3 bucket in which to stash delete logs.
  * `tagPatterns` - should use `jq` syntax to generate `{tagKey: tagValue}` objects from output from `grafiti parse`. The results will be included in the `Tags` field of the tagging output.
  * `filterPatterns` - will filter output of `grafiti parse` based on `jq` syntax matches.
 

--- a/arn/arn.go
+++ b/arn/arn.go
@@ -136,6 +136,8 @@ const (
 	EC2NatGatewayRType = "AWS::EC2::NatGateway"
 	// EC2NetworkACLRType is an AWS ResourceType enum value
 	EC2NetworkACLRType = "AWS::EC2::NetworkAcl"
+	// EC2NetworkACLEntryRType is an AWS ResourceType enum value
+	EC2NetworkACLEntryRType = "AWS::EC2::NetworkAclEntry"
 	// EC2NetworkInterfaceRType is an AWS ResourceType enum value
 	EC2NetworkInterfaceRType = "AWS::EC2::NetworkInterface"
 	// EC2NetworkInterfaceAttachmentRType is an AWS ResourceType enum value

--- a/cmd/grafiti/delete.go
+++ b/cmd/grafiti/delete.go
@@ -431,7 +431,7 @@ func deleteARNs(ARNs arn.ResourceARNs) error {
 
 	// Create log filename
 	t := time.Now()
-	logFilePath := fmt.Sprintf("./delete-log-data-%d-%d-%d.log", t.Year(), t.Month(), t.Day())
+	logFilePath := fmt.Sprintf("./deleted-resources-%d%02d%02d_%02d%02d%02d.log", t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second())
 
 	cfg := &deleter.DeleteConfig{
 		IgnoreErrors: ignoreErrors,
@@ -509,12 +509,17 @@ const logTail = `=================================================`
 const logHead = logTail + "\n== Log Report: Failed Resource Deletion Events ==\n" + logTail
 
 func formatReportLogEntry(e *deleter.LogEntry) (m string) {
+	if e.Error == nil {
+		return ""
+	}
+
 	m = fmt.Sprintf("Failed to delete %s %s", e.ResourceType, e.ResourceName)
 
-	switch {
-	case e.ParentResourceName != "":
+	if e.ParentResourceName != "" {
 		m = fmt.Sprintf("%s from %s %s", m, e.ParentResourceType, e.ParentResourceName)
-		fallthrough
+	}
+
+	switch {
 	case e.AWSErrorCode != "" && e.AWSErrorMsg != "":
 		m = fmt.Sprintf("%s (%s: %s)", m, e.AWSErrorCode, e.AWSErrorMsg)
 	case e.ErrMsg != "":

--- a/cmd/grafiti/delete.go
+++ b/cmd/grafiti/delete.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"time"
 
@@ -30,9 +31,11 @@ import (
 	rgtaiface "github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/route53/route53iface"
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/coreos/grafiti/arn"
 	"github.com/coreos/grafiti/deleter"
 	"github.com/coreos/grafiti/graph"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -460,6 +463,13 @@ func deleteARNs(ARNs arn.ResourceARNs) error {
 		fmt.Println(logTail)
 	}
 
+	// Stash the log in an S3 bucket provided by the user. Dry run date won't
+	// be sent
+	bucketName := viper.GetString("logS3BucketName")
+	if bucketName != "" && !dryRun {
+		stashInS3Bucket(logFilePath, bucketName)
+	}
+
 	return nil
 }
 
@@ -526,5 +536,47 @@ func formatReportLogEntry(e *deleter.LogEntry) (m string) {
 		m = fmt.Sprintf("%s (%s)", m, e.ErrMsg)
 	}
 
+	return
+}
+
+// Stash a file in an S3 bucket
+func stashInS3Bucket(path, bucketName string) {
+	svc := s3.New(session.Must(session.NewSession(
+		&aws.Config{
+			Region: aws.String(viper.GetString("region")),
+		},
+	)))
+
+	f, err := os.Open(path)
+	if err != nil {
+		logrus.Errorln("Failed to open log file %s: %s\n", path, err)
+		return
+	}
+	defer f.Close()
+
+	params := &s3.PutObjectInput{
+		Body:   f,
+		Bucket: aws.String(bucketName),
+		Key:    aws.String(path),
+	}
+
+	// File information
+	if fi, ierr := f.Stat(); ierr != nil {
+		params.ContentLength = aws.Int64(fi.Size())
+
+		buf := make([]byte, fi.Size())
+		f.Read(buf)
+		f.Seek(0, 0)
+
+		params.ContentType = aws.String(http.DetectContentType(buf))
+	}
+
+	ctx := aws.BackgroundContext()
+	if _, err = svc.PutObjectWithContext(ctx, params); err != nil {
+		logrus.Errorln(err)
+		return
+	}
+
+	logrus.Infoln("Log data sent to S3 bucket", bucketName)
 	return
 }

--- a/config.toml
+++ b/config.toml
@@ -6,6 +6,7 @@ startHour = -8
 region = "us-west-2"
 maxNumRequestRetries = 8
 includeEvent = false
+logS3BucketName = "grafiti-test-bucket"
 tagPatterns = [
   "{CreatedBy: .userIdentity.arn}",
   # "{CreatedAt: .eventTime}",

--- a/deleter/autoscaling.go
+++ b/deleter/autoscaling.go
@@ -58,13 +58,14 @@ func (rd *AutoScalingGroupDeleter) DeleteResources(cfg *DeleteConfig) error {
 		ctx := aws.BackgroundContext()
 		_, err := rd.GetClient().DeleteAutoScalingGroupWithContext(ctx, params)
 		if err != nil {
-			cfg.logDeleteError(arn.AutoScalingGroupRType, n, err)
+			cfg.logRequestError(arn.AutoScalingGroupRType, n, err)
 			if cfg.IgnoreErrors {
 				continue
 			}
 			return err
 		}
 
+		cfg.logRequestSuccess(arn.AutoScalingGroupRType, n)
 		fmt.Println(fmtStr, n)
 	}
 
@@ -149,13 +150,14 @@ func (rd *AutoScalingLaunchConfigurationDeleter) DeleteResources(cfg *DeleteConf
 		ctx := aws.BackgroundContext()
 		_, err := rd.GetClient().DeleteLaunchConfigurationWithContext(ctx, params)
 		if err != nil {
-			cfg.logDeleteError(arn.AutoScalingLaunchConfigurationRType, n, err)
+			cfg.logRequestError(arn.AutoScalingLaunchConfigurationRType, n, err)
 			if cfg.IgnoreErrors {
 				continue
 			}
 			return err
 		}
 
+		cfg.logRequestSuccess(arn.AutoScalingLaunchConfigurationRType, n)
 		fmt.Println(fmtStr, n)
 	}
 

--- a/deleter/elb.go
+++ b/deleter/elb.go
@@ -48,8 +48,10 @@ func (rd *ElasticLoadBalancingLoadBalancerDeleter) DeleteResources(cfg *DeleteCo
 
 	var params *elb.DeleteLoadBalancerInput
 	for _, lb := range lbs {
+		nameStr := aws.StringValue(lb.LoadBalancerName)
+
 		if cfg.DryRun {
-			fmt.Println(drStr, fmtStr, *lb.LoadBalancerName)
+			fmt.Println(drStr, fmtStr, nameStr)
 			continue
 		}
 
@@ -60,14 +62,15 @@ func (rd *ElasticLoadBalancingLoadBalancerDeleter) DeleteResources(cfg *DeleteCo
 		ctx := aws.BackgroundContext()
 		_, err := rd.GetClient().DeleteLoadBalancerWithContext(ctx, params)
 		if err != nil {
-			cfg.logDeleteError(arn.ElasticLoadBalancingLoadBalancerRType, arn.ResourceName(*lb.LoadBalancerName), err)
+			cfg.logRequestError(arn.ElasticLoadBalancingLoadBalancerRType, nameStr, err)
 			if cfg.IgnoreErrors {
 				continue
 			}
 			return err
 		}
 
-		fmt.Println(fmtStr, *lb.LoadBalancerName)
+		cfg.logRequestSuccess(arn.ElasticLoadBalancingLoadBalancerRType, nameStr)
+		fmt.Println(fmtStr, nameStr)
 	}
 
 	return nil

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -1,8 +1,6 @@
 package graph
 
 import (
-	"fmt"
-
 	"github.com/coreos/grafiti/arn"
 	"github.com/coreos/grafiti/deleter"
 )
@@ -68,7 +66,6 @@ func traverseDependencyGraph(rt arn.ResourceType, depMap map[arn.ResourceType]de
 
 		vpcDel.ResourceNames = nil
 		for _, vpc := range vpcs {
-			fmt.Println("VPC:", *vpc.VpcId)
 			vpcDel.AddResourceNames(arn.ResourceName(*vpc.VpcId))
 		}
 
@@ -78,7 +75,6 @@ func traverseDependencyGraph(rt arn.ResourceType, depMap map[arn.ResourceType]de
 			depMap[arn.EC2InstanceRType] = deleter.InitResourceDeleter(arn.EC2InstanceRType)
 		}
 		for _, instance := range instances {
-			fmt.Println("EC2InstanceRType:", *instance.InstanceId)
 			depMap[arn.EC2InstanceRType].AddResourceNames(arn.ResourceName(*instance.InstanceId))
 		}
 
@@ -88,7 +84,6 @@ func traverseDependencyGraph(rt arn.ResourceType, depMap map[arn.ResourceType]de
 			depMap[arn.EC2InternetGatewayRType] = deleter.InitResourceDeleter(arn.EC2InternetGatewayRType)
 		}
 		for _, igw := range igws {
-			fmt.Println("EC2InternetGatewayRType:", *igw.InternetGatewayId)
 			depMap[arn.EC2InternetGatewayRType].AddResourceNames(arn.ResourceName(*igw.InternetGatewayId))
 		}
 
@@ -98,7 +93,6 @@ func traverseDependencyGraph(rt arn.ResourceType, depMap map[arn.ResourceType]de
 			depMap[arn.EC2NatGatewayRType] = deleter.InitResourceDeleter(arn.EC2NatGatewayRType)
 		}
 		for _, ngw := range ngws {
-			fmt.Println("EC2NatGatewayRType:", *ngw.NatGatewayId)
 			depMap[arn.EC2NatGatewayRType].AddResourceNames(arn.ResourceName(*ngw.NatGatewayId))
 		}
 
@@ -108,7 +102,6 @@ func traverseDependencyGraph(rt arn.ResourceType, depMap map[arn.ResourceType]de
 			depMap[arn.EC2NetworkInterfaceRType] = deleter.InitResourceDeleter(arn.EC2NetworkInterfaceRType)
 		}
 		for _, eni := range enis {
-			fmt.Println("EC2NetworkInterfaceRType:", *eni.NetworkInterfaceId)
 			depMap[arn.EC2NetworkInterfaceRType].AddResourceNames(arn.ResourceName(*eni.NetworkInterfaceId))
 		}
 
@@ -118,7 +111,6 @@ func traverseDependencyGraph(rt arn.ResourceType, depMap map[arn.ResourceType]de
 			depMap[arn.EC2RouteTableRType] = deleter.InitResourceDeleter(arn.EC2RouteTableRType)
 		}
 		for _, rt := range rts {
-			fmt.Println("EC2RouteTableRType:", *rt.RouteTableId)
 			depMap[arn.EC2RouteTableRType].AddResourceNames(arn.ResourceName(*rt.RouteTableId))
 		}
 
@@ -128,7 +120,6 @@ func traverseDependencyGraph(rt arn.ResourceType, depMap map[arn.ResourceType]de
 			depMap[arn.EC2SecurityGroupRType] = deleter.InitResourceDeleter(arn.EC2SecurityGroupRType)
 		}
 		for _, sg := range sgs {
-			fmt.Println("EC2SecurityGroupRType:", *sg.GroupId)
 			depMap[arn.EC2SecurityGroupRType].AddResourceNames(arn.ResourceName(*sg.GroupId))
 		}
 
@@ -138,7 +129,6 @@ func traverseDependencyGraph(rt arn.ResourceType, depMap map[arn.ResourceType]de
 			depMap[arn.EC2SubnetRType] = deleter.InitResourceDeleter(arn.EC2SubnetRType)
 		}
 		for _, sn := range sns {
-			fmt.Println("EC2SubnetRType:", *sn.SubnetId)
 			depMap[arn.EC2SubnetRType].AddResourceNames(arn.ResourceName(*sn.SubnetId))
 		}
 
@@ -148,7 +138,6 @@ func traverseDependencyGraph(rt arn.ResourceType, depMap map[arn.ResourceType]de
 			depMap[arn.EC2VPNGatewayRType] = deleter.InitResourceDeleter(arn.EC2VPNGatewayRType)
 		}
 		for _, vgw := range vgws {
-			fmt.Println("EC2VPNGatewayRType:", *vgw.VpnGatewayId)
 			depMap[arn.EC2VPNGatewayRType].AddResourceNames(arn.ResourceName(*vgw.VpnGatewayId))
 		}
 	case arn.EC2VPNGatewayRType:
@@ -163,7 +152,6 @@ func traverseDependencyGraph(rt arn.ResourceType, depMap map[arn.ResourceType]de
 			depMap[arn.EC2VPNConnectionRType] = deleter.InitResourceDeleter(arn.EC2VPNConnectionRType)
 		}
 		for _, vc := range vcs {
-			fmt.Println("EC2VPNConnectionRType:", *vc.VpnConnectionId)
 			depMap[arn.EC2VPNConnectionRType].AddResourceNames(arn.ResourceName(*vc.VpnConnectionId))
 		}
 	case arn.EC2SubnetRType:
@@ -183,11 +171,9 @@ func traverseDependencyGraph(rt arn.ResourceType, depMap map[arn.ResourceType]de
 			depMap[arn.IAMRoleRType] = deleter.InitResourceDeleter(arn.IAMRoleRType)
 		}
 		for _, ipr := range iprs {
-			fmt.Println("IAMInstanceProfileRType:", *ipr.InstanceProfileName)
 			depMap[arn.IAMInstanceProfileRType].AddResourceNames(arn.ResourceName(*ipr.InstanceProfileName))
 			// Get IAM roles
 			for _, rl := range ipr.Roles {
-				fmt.Println("IAMRoleRType:", *rl.RoleName)
 				depMap[arn.IAMRoleRType].AddResourceNames(arn.ResourceName(*rl.RoleName))
 			}
 		}
@@ -209,11 +195,9 @@ func traverseDependencyGraph(rt arn.ResourceType, depMap map[arn.ResourceType]de
 		}
 		for _, adr := range adrs {
 			if adr.AllocationId != nil {
-				fmt.Println("EC2EIPRType:", *adr.AllocationId)
 				depMap[arn.EC2EIPRType].AddResourceNames(arn.ResourceName(*adr.AllocationId))
 			}
 			if adr.AssociationId != nil {
-				fmt.Println("EC2EIPAssociationRType:", *adr.AssociationId)
 				depMap[arn.EC2EIPAssociationRType].AddResourceNames(arn.ResourceName(*adr.AssociationId))
 			}
 		}
@@ -232,7 +216,6 @@ func traverseDependencyGraph(rt arn.ResourceType, depMap map[arn.ResourceType]de
 		for _, rt := range rts {
 			for _, rta := range rt.Associations {
 				if rta.Main != nil && !*rta.Main {
-					fmt.Println("EC2RouteTableAssociationRType:", *rta.RouteTableAssociationId)
 					depMap[arn.EC2RouteTableAssociationRType].AddResourceNames(arn.ResourceName(*rta.RouteTableAssociationId))
 				}
 			}
@@ -253,11 +236,8 @@ func traverseDependencyGraph(rt arn.ResourceType, depMap map[arn.ResourceType]de
 			depMap[arn.ElasticLoadBalancingLoadBalancerRType] = deleter.InitResourceDeleter(arn.ElasticLoadBalancingLoadBalancerRType)
 		}
 		for _, asg := range asgs {
-			fmt.Println("AutoScalingGroupRType:", *asg.AutoScalingGroupName)
-			fmt.Println("AutoScalingLaunchConfigurationRType:", *asg.LaunchConfigurationName)
 			depMap[arn.AutoScalingLaunchConfigurationRType].AddResourceNames(arn.ResourceName(*asg.LaunchConfigurationName))
 			for _, elbName := range asg.LoadBalancerNames {
-				fmt.Println("ElasticLoadBalancingLoadBalancerRType:", *elbName)
 				depMap[arn.ElasticLoadBalancingLoadBalancerRType].AddResourceNames(arn.ResourceName(*elbName))
 			}
 		}
@@ -276,11 +256,9 @@ func traverseDependencyGraph(rt arn.ResourceType, depMap map[arn.ResourceType]de
 			depMap[arn.IAMRoleRType] = deleter.InitResourceDeleter(arn.IAMRoleRType)
 		}
 		for _, ipr := range iprs {
-			fmt.Println("IAMInstanceProfileRType:", *ipr.InstanceProfileName)
 			depMap[arn.IAMInstanceProfileRType].AddResourceNames(arn.ResourceName(*ipr.InstanceProfileName))
 			// Get IAM roles
 			for _, rl := range ipr.Roles {
-				fmt.Println("IAMRoleRType:", *rl.RoleName)
 				depMap[arn.IAMRoleRType].AddResourceNames(arn.ResourceName(*rl.RoleName))
 			}
 		}

--- a/testdata/config/test-config.toml
+++ b/testdata/config/test-config.toml
@@ -6,6 +6,7 @@ startHour = -8
 region = "us-west-2"
 maxNumRequestRetries = 8
 includeEvent = false
+logS3BucketName = "grafiti-test-bucket"
 tagPatterns = [
   # "{CreatedBy: .userIdentity.arn}",
   # "{CreatedAt: .eventTime}",


### PR DESCRIPTION
cmd/grafiti: reworked log entry formatter to report only resources that failed to delete if using `--report`, added `logS3BucketName` config field to specify what bucket to send log data to.

Tests: manually tested by deleting cluster, observed log in bucket.

*Note:* while this PR looks long, most of the changes are additions of `logReuqestSuccess()` to `DeleteResources()`.

Fixes #97 

Review after #101 is merged