### PR TITLE
Prevent attached EC2 eni's from being deleted

### DIFF
--- a/deleter/deleter.go
+++ b/deleter/deleter.go
@@ -205,8 +205,6 @@ func InitResourceDeleter(t arn.ResourceType) ResourceDeleter {
 		return &EC2NetworkACLDeleter{ResourceType: t}
 	case arn.EC2NetworkInterfaceRType:
 		return &EC2NetworkInterfaceDeleter{ResourceType: t}
-	case arn.EC2NetworkInterfaceAttachmentRType:
-		return &EC2NetworkInterfaceAttachmentDeleter{ResourceType: t}
 	case arn.EC2RouteTableAssociationRType:
 		return &EC2RouteTableAssociationDeleter{ResourceType: t}
 	case arn.EC2RouteTableRType:

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -158,6 +158,16 @@ func traverseDependencyGraph(rt arn.ResourceType, depMap map[arn.ResourceType]de
 		// Get Network ACL's
 	case arn.EC2InstanceRType:
 		instanceDel := depMap[rt].(*deleter.EC2InstanceDeleter)
+
+		// Get EC2 network interfaces
+		enis, _ := instanceDel.RequestEC2NetworkInterfacesFromInstances()
+		if _, ok := depMap[arn.EC2NetworkInterfaceRType]; !ok {
+			depMap[arn.EC2NetworkInterfaceRType] = deleter.InitResourceDeleter(arn.EC2NetworkInterfaceRType)
+		}
+		for _, eni := range enis {
+			depMap[arn.EC2NetworkInterfaceRType].AddResourceNames(arn.ResourceName(*eni.NetworkInterfaceId))
+		}
+
 		// Get IAM instance profiles
 		iprs, err := instanceDel.RequestIAMInstanceProfilesFromInstances()
 		if err != nil || len(iprs) == 0 {


### PR DESCRIPTION
deleter: prevent attached EC2 eni's from being deleted, refactored eni attachment deleter

graph: added instance -> eni traverse step, so that in the case of no VPC, eni's can still be found and 
deleted by their attached instance

If an EC2 network interface is attached to an instance, skip deletion.