### PR TITLE
Log errors to stderr with 'logrus'

### DIFF
--- a/arn/arn.go
+++ b/arn/arn.go
@@ -2,15 +2,24 @@ package arn
 
 import (
 	"fmt"
+	"os"
 	re "regexp"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/tidwall/gjson"
 )
+
+// logger prints errors in JSON format without a timestamp
+var logger = logrus.Logger{
+	Out:       os.Stderr,
+	Formatter: &logrus.JSONFormatter{DisableTimestamp: true},
+	Level:     logrus.InfoLevel,
+}
 
 // ResourceARN aliases a string type for ARNs
 type ResourceARN string
@@ -639,7 +648,7 @@ func MapARNToRTypeAndRName(arnStr ResourceARN) (ResourceType, ResourceName) {
 	case strings.HasPrefix(arn, "arn:aws:autoscaling:"):
 		erASG, err := re.Compile("arn:aws:autoscaling:[^:]+:[^:]+:(.+)")
 		if err != nil {
-			fmt.Printf("{\"error\": \"%s\"}\n", err.Error())
+			logger.Errorln(err)
 			break
 		}
 		m := erASG.FindStringSubmatch(arn)
@@ -658,7 +667,7 @@ func MapARNToRTypeAndRName(arnStr ResourceARN) (ResourceType, ResourceName) {
 	case strings.HasPrefix(arn, "arn:aws:ec2:"):
 		erEC2, err := re.Compile("arn:aws:ec2:[^:]+:(?:[^:]+:)?(.+)")
 		if err != nil {
-			fmt.Printf("{\"error\": \"%s\"}\n", err.Error())
+			logger.Errorln(err)
 			break
 		}
 		m := erEC2.FindStringSubmatch(arn)
@@ -700,7 +709,7 @@ func MapARNToRTypeAndRName(arnStr ResourceARN) (ResourceType, ResourceName) {
 	case strings.HasPrefix(arn, "arn:aws:iam::"):
 		erIAM, err := re.Compile("arn:aws:iam::[^:]+:(.+)")
 		if err != nil {
-			fmt.Printf("{\"error\": \"%s\"}\n", err.Error())
+			logger.Errorln(err)
 			break
 		}
 		m := erIAM.FindStringSubmatch(arn)

--- a/cmd/grafiti/tag_test.go
+++ b/cmd/grafiti/tag_test.go
@@ -300,9 +300,7 @@ func TestTagAutoScalingResource(t *testing.T) {
 	}
 
 	f := func(v interface{}, rt arn.ResourceType, rn arn.ResourceName, t Tags) {
-		rns := make(ResourceNameSet)
-		rns[rn] = t
-		tagAutoScalingResources(v.(autoscalingiface.AutoScalingAPI), rt, rns)
+		tagAutoScalingResources(v.(autoscalingiface.AutoScalingAPI), rt, rn, t)
 	}
 
 	for i, c := range cases {

--- a/deleter/autoscaling.go
+++ b/deleter/autoscaling.go
@@ -5,11 +5,17 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/coreos/grafiti/arn"
 )
+
+func isValidationError(err error) bool {
+	aerr, ok := err.(awserr.Error)
+	return ok && aerr.Code() == ErrCodeValidationError
+}
 
 // AutoScalingGroupDeleter represents an AWS autoscaling group
 type AutoScalingGroupDeleter struct {
@@ -72,36 +78,42 @@ func (rd *AutoScalingGroupDeleter) DeleteResources(cfg *DeleteConfig) error {
 	return nil
 }
 
-// RequestAutoScalingGroups requests autoscaling groups from the AWS API and returns autoscaling
-// groups by names
+// RequestAutoScalingGroups requests resources from the AWS API and returns
+// autoscaling groups by names
 func (rd *AutoScalingGroupDeleter) RequestAutoScalingGroups() ([]*autoscaling.Group, error) {
 	if len(rd.ResourceNames) == 0 {
 		return nil, nil
 	}
 
-	asgs := make([]*autoscaling.Group, 0)
+	lcs := make([]*autoscaling.Group, 0)
+	var err error
+	// Requesting a batch of resources that contains at least one already deleted
+	// resource will return an error and no resources. To guard against this,
+	// request them one by one
+	for _, name := range rd.ResourceNames {
+		if lcs, err = rd.requestAutoScalingGroup(name, lcs); err != nil && !isValidationError(err) {
+			return lcs, err
+		}
+	}
+
+	return lcs, nil
+}
+
+func (rd *AutoScalingGroupDeleter) requestAutoScalingGroup(rn arn.ResourceName, lcs []*autoscaling.Group) ([]*autoscaling.Group, error) {
 	params := &autoscaling.DescribeAutoScalingGroupsInput{
-		AutoScalingGroupNames: rd.ResourceNames.AWSStringSlice(),
+		AutoScalingGroupNames: []*string{rn.AWSString()},
 	}
 
-	for {
-		ctx := aws.BackgroundContext()
-		resp, err := rd.GetClient().DescribeAutoScalingGroupsWithContext(ctx, params)
-		if err != nil {
-			fmt.Printf("{\"error\": \"%s\"}\n", err)
-			return asgs, err
-		}
-
-		asgs = append(asgs, resp.AutoScalingGroups...)
-
-		if aws.StringValue(resp.NextToken) == "" {
-			break
-		}
-
-		params.NextToken = resp.NextToken
+	ctx := aws.BackgroundContext()
+	resp, err := rd.GetClient().DescribeAutoScalingGroupsWithContext(ctx, params)
+	if err != nil {
+		logger.Errorln(err)
+		return lcs, err
 	}
 
-	return asgs, nil
+	lcs = append(lcs, resp.AutoScalingGroups...)
+
+	return lcs, nil
 }
 
 // AutoScalingLaunchConfigurationDeleter represents an AWS launch configuration
@@ -171,14 +183,13 @@ func (rd *AutoScalingLaunchConfigurationDeleter) RequestAutoScalingLaunchConfigu
 		return nil, nil
 	}
 
-	size, chunk := len(rd.ResourceNames), 20
 	lcs := make([]*autoscaling.LaunchConfiguration, 0)
 	var err error
-	// Can only filter in batches of 20
-	for i := 0; i < size; i += chunk {
-		stop := CalcChunk(i, size, chunk)
-		lcs, err = rd.requestAutoScalingLaunchConfigurations(rd.ResourceNames[i:stop], lcs)
-		if err != nil {
+	// Requesting a batch of resources that contains at least one already deleted
+	// resource will return an error and no resources. To guard against this,
+	// request them one by one
+	for _, name := range rd.ResourceNames {
+		if lcs, err = rd.requestAutoScalingLaunchConfiguration(name, lcs); err != nil && !isValidationError(err) {
 			return lcs, err
 		}
 	}
@@ -186,29 +197,19 @@ func (rd *AutoScalingLaunchConfigurationDeleter) RequestAutoScalingLaunchConfigu
 	return lcs, nil
 }
 
-// Requesting internet gateways using filters prevents API errors caused by
-// requesting non-existent internet gateways
-func (rd *AutoScalingLaunchConfigurationDeleter) requestAutoScalingLaunchConfigurations(chunk arn.ResourceNames, lcs []*autoscaling.LaunchConfiguration) ([]*autoscaling.LaunchConfiguration, error) {
+func (rd *AutoScalingLaunchConfigurationDeleter) requestAutoScalingLaunchConfiguration(rn arn.ResourceName, lcs []*autoscaling.LaunchConfiguration) ([]*autoscaling.LaunchConfiguration, error) {
 	params := &autoscaling.DescribeLaunchConfigurationsInput{
-		LaunchConfigurationNames: chunk.AWSStringSlice(),
+		LaunchConfigurationNames: []*string{rn.AWSString()},
 	}
 
-	for {
-		ctx := aws.BackgroundContext()
-		resp, err := rd.GetClient().DescribeLaunchConfigurationsWithContext(ctx, params)
-		if err != nil {
-			fmt.Printf("{\"error\": \"%s\"}\n", err)
-			return lcs, err
-		}
-
-		lcs = append(lcs, resp.LaunchConfigurations...)
-
-		if aws.StringValue(resp.NextToken) == "" {
-			break
-		}
-
-		params.NextToken = resp.NextToken
+	ctx := aws.BackgroundContext()
+	resp, err := rd.GetClient().DescribeLaunchConfigurationsWithContext(ctx, params)
+	if err != nil {
+		logger.Errorln(err)
+		return lcs, err
 	}
+
+	lcs = append(lcs, resp.LaunchConfigurations...)
 
 	return lcs, nil
 }
@@ -234,7 +235,7 @@ func (rd *AutoScalingLaunchConfigurationDeleter) RequestIAMInstanceProfilesFromL
 		ctx := aws.BackgroundContext()
 		resp, err := svc.ListInstanceProfilesWithContext(ctx, params)
 		if err != nil {
-			fmt.Printf("{\"error\": \"%s\"}\n", err)
+			logger.Errorln(err)
 			return iprs, err
 		}
 

--- a/deleter/deleter.go
+++ b/deleter/deleter.go
@@ -17,6 +17,12 @@ import (
 
 const drStr = "(dry-run)"
 
+// Error codes not defined by aws-sdk-go
+
+// ErrCodeValidationError is returned when a request did not conform to AWS API
+// backend expectations, ex. when a requested resource cannot be found
+const ErrCodeValidationError = "ValidationError"
+
 func setUpAWSSession() *session.Session {
 	maxRetries := viper.GetInt("maxNumRequestRetries")
 	return session.Must(session.NewSession(
@@ -33,6 +39,14 @@ func CalcChunk(curr, size, chunk int) int {
 		return size
 	}
 	return curr + chunk
+}
+
+// logger prints errors in JSON format without a timestamp. Used for reporting
+// Describe/List/Get API request errors
+var logger = logrus.Logger{
+	Out:       os.Stderr,
+	Formatter: &logrus.JSONFormatter{DisableTimestamp: true},
+	Level:     logrus.InfoLevel,
 }
 
 // DeleteConfig holds configuration info for resource deletion

--- a/deleter/ec2.go
+++ b/deleter/ec2.go
@@ -165,7 +165,7 @@ func (c *EC2Client) requestEC2CustomerGateways(filterKey string, chunk arn.Resou
 	ctx := aws.BackgroundContext()
 	resp, err := c.DescribeCustomerGatewaysWithContext(ctx, params)
 	if err != nil {
-		fmt.Printf("{\"error\": \"%s\"}\n", err)
+		logger.Errorln(err)
 		return cgws, err
 	}
 
@@ -420,7 +420,7 @@ func (c *EC2Client) requestEC2NetworkInterfaces(filterKey string, chunk arn.Reso
 	ctx := aws.BackgroundContext()
 	resp, err := c.DescribeNetworkInterfacesWithContext(ctx, params)
 	if err != nil {
-		fmt.Printf("{\"error\": \"%s\"}\n", err)
+		logger.Errorln(err)
 		return enis, err
 	}
 
@@ -461,7 +461,7 @@ func (c *EC2Client) requestEC2EIPAddresses(filterKey string, chunk arn.ResourceN
 	ctx := aws.BackgroundContext()
 	resp, err := c.DescribeAddressesWithContext(ctx, params)
 	if err != nil {
-		fmt.Printf("{\"error\": \"%s\"}\n", err)
+		logger.Errorln(err)
 		return addresses, err
 	}
 
@@ -710,7 +710,7 @@ func (c *EC2Client) requestEC2NetworkACLs(filterKey string, chunk arn.ResourceNa
 	ctx := aws.BackgroundContext()
 	resp, err := c.DescribeNetworkAclsWithContext(ctx, params)
 	if err != nil {
-		fmt.Printf("{\"error\": \"%s\"}\n", err)
+		logger.Errorln(err)
 		return acls, err
 	}
 
@@ -862,7 +862,7 @@ func (c *EC2Client) requestEC2Instances(filterKey string, chunk arn.ResourceName
 		ctx := aws.BackgroundContext()
 		resp, err := c.DescribeInstancesWithContext(ctx, params)
 		if err != nil {
-			fmt.Printf("{\"error\": \"%s\"}\n", err)
+			logger.Errorln(err)
 			return instances, err
 		}
 
@@ -932,7 +932,7 @@ func (rd *EC2InstanceDeleter) RequestIAMInstanceProfilesFromInstances() ([]*iam.
 		ctx := aws.BackgroundContext()
 		resp, err := svc.ListInstanceProfilesWithContext(ctx, params)
 		if err != nil {
-			fmt.Printf("{\"error\": \"%s\"}\n", err)
+			logger.Errorln(err)
 			return nil, err
 		}
 
@@ -1149,7 +1149,7 @@ func (c *EC2Client) requestEC2InternetGateways(filterKey string, chunk arn.Resou
 	ctx := aws.BackgroundContext()
 	resp, err := c.DescribeInternetGatewaysWithContext(ctx, params)
 	if err != nil {
-		fmt.Printf("{\"error\": \"%s\"}\n", err)
+		logger.Errorln(err)
 		return igws, err
 	}
 
@@ -1278,7 +1278,7 @@ func (c *EC2Client) filterDeletedNATGateways(ngws []*ec2.NatGateway) ([]*ec2.Nat
 			ctx := aws.BackgroundContext()
 			resp, err := c.DescribeNatGatewaysWithContext(ctx, params)
 			if err != nil {
-				fmt.Printf("{\"error\": \"%s\"}\n", err)
+				logger.Errorln(err)
 				return deletedNGWs, aliveNGWs, err
 			}
 
@@ -1360,7 +1360,7 @@ func (c *EC2Client) requestEC2NatGateways(filterKey string, chunk arn.ResourceNa
 		ctx := aws.BackgroundContext()
 		resp, err := c.DescribeNatGatewaysWithContext(ctx, params)
 		if err != nil {
-			fmt.Printf("{\"error\": \"%s\"}\n", err)
+			logger.Errorln(err)
 			return ngws, err
 		}
 
@@ -1630,7 +1630,7 @@ func (c *EC2Client) requestEC2RouteTables(filterKey string, chunk arn.ResourceNa
 	ctx := aws.BackgroundContext()
 	resp, err := c.DescribeRouteTablesWithContext(ctx, params)
 	if err != nil {
-		fmt.Printf("{\"error\": \"%s\"}\n", err)
+		logger.Errorln(err)
 		return rtbs, err
 	}
 
@@ -1910,7 +1910,7 @@ func (c *EC2Client) requestEC2SecurityGroups(filterKey string, chunk arn.Resourc
 	ctx := aws.BackgroundContext()
 	resp, err := c.DescribeSecurityGroupsWithContext(ctx, params)
 	if err != nil {
-		fmt.Printf("{\"error\": \"%s\"}\n", err)
+		logger.Errorln(err)
 		return sgs, err
 	}
 
@@ -2030,7 +2030,7 @@ func (c *EC2Client) requestEC2Subnets(filterKey string, chunk arn.ResourceNames,
 	ctx := aws.BackgroundContext()
 	resp, err := c.DescribeSubnetsWithContext(ctx, params)
 	if err != nil {
-		fmt.Printf("{\"error\": \"%s\"}\n", err)
+		logger.Errorln(err)
 		return subnets, err
 	}
 
@@ -2213,7 +2213,7 @@ func (c *EC2Client) requestEC2Volumes(filterKey string, chunk arn.ResourceNames,
 		ctx := aws.BackgroundContext()
 		resp, err := c.DescribeVolumesWithContext(ctx, params)
 		if err != nil {
-			fmt.Printf("{\"error\": \"%s\"}\n", err)
+			logger.Errorln(err)
 			return vols, err
 		}
 
@@ -2355,7 +2355,7 @@ func (c *EC2Client) requestEC2VPCs(filterKey string, chunk arn.ResourceNames, vp
 	ctx := aws.BackgroundContext()
 	resp, err := c.DescribeVpcsWithContext(ctx, params)
 	if err != nil {
-		fmt.Printf("{\"error\": \"%s\"}\n", err)
+		logger.Errorln(err)
 		return vpcs, err
 	}
 
@@ -2727,7 +2727,7 @@ func (c *EC2Client) requestEC2VPNConnections(filterKey string, chunk arn.Resourc
 	ctx := aws.BackgroundContext()
 	resp, err := c.DescribeVpnConnectionsWithContext(ctx, params)
 	if err != nil {
-		fmt.Printf("{\"error\": \"%s\"}\n", err)
+		logger.Errorln(err)
 		return vconns, err
 	}
 
@@ -2928,7 +2928,7 @@ func (c *EC2Client) requestEC2VPNGateways(filterKey string, chunk arn.ResourceNa
 	ctx := aws.BackgroundContext()
 	resp, err := c.DescribeVpnGatewaysWithContext(ctx, params)
 	if err != nil {
-		fmt.Printf("{\"error\": \"%s\"}\n", err)
+		logger.Errorln(err)
 		return vgws, err
 	}
 

--- a/deleter/iam.go
+++ b/deleter/iam.go
@@ -147,7 +147,7 @@ func (rd *IAMInstanceProfileDeleter) RequestIAMInstanceProfiles() ([]*iam.Instan
 		ctx := aws.BackgroundContext()
 		resp, err := rd.GetClient().ListInstanceProfilesWithContext(ctx, params)
 		if err != nil {
-			fmt.Printf("{\"error\": \"%s\"}\n", err)
+			logger.Errorln(err)
 			return iprs, err
 		}
 
@@ -273,7 +273,7 @@ func (rd *IAMRoleDeleter) RequestIAMRoles() ([]*iam.Role, error) {
 		ctx := aws.BackgroundContext()
 		resp, err := rd.GetClient().ListRolesWithContext(ctx, params)
 		if err != nil {
-			fmt.Printf("{\"error\": \"%s\"}\n", err)
+			logger.Errorln(err)
 			return rls, err
 		}
 
@@ -378,7 +378,7 @@ func (rd *IAMRolePolicyDeleter) RequestIAMRolePoliciesFromRoles() (arn.ResourceN
 		ctx := aws.BackgroundContext()
 		resp, err := rd.GetClient().ListRolePoliciesWithContext(ctx, params)
 		if err != nil {
-			fmt.Printf("{\"error\": \"%s\"}\n", err)
+			logger.Errorln(err)
 			return policyNames, err
 		}
 

--- a/deleter/route53.go
+++ b/deleter/route53.go
@@ -137,7 +137,7 @@ func (rd *Route53HostedZoneDeleter) RequestAllRoute53HostedZones() ([]*route53.H
 		ctx := aws.BackgroundContext()
 		resp, err := rd.GetClient().ListHostedZonesWithContext(ctx, params)
 		if err != nil {
-			fmt.Printf("{\"error\": \"%s\"}\n", err)
+			logger.Errorln(err)
 			return hzs, err
 		}
 
@@ -315,7 +315,7 @@ func (rd *Route53ResourceRecordSetDeleter) RequestRoute53ResourceRecordSets() ([
 		ctx := aws.BackgroundContext()
 		resp, err := rd.GetClient().ListResourceRecordSetsWithContext(ctx, params)
 		if err != nil {
-			fmt.Printf("{\"error\": \"%s\"}\n", err)
+			logger.Errorln(err)
 			return recordSets, err
 		}
 

--- a/deleter/s3.go
+++ b/deleter/s3.go
@@ -94,7 +94,7 @@ func (rd *S3ObjectDeleter) RequestS3ObjectsFromBucket() ([]*s3.Object, error) {
 		ctx := aws.BackgroundContext()
 		resp, err := rd.GetClient().ListObjectsV2WithContext(ctx, params)
 		if err != nil {
-			fmt.Printf("{\"error\": \"%s\"}\n", err)
+			logger.Errorln(err)
 			return objs, err
 		}
 


### PR DESCRIPTION
arn,cmd/grafiti,deleter: added package-scoped (internal) loggers to log Describe/List/Get API errors to stderr

deleter: better error handling in autoscaling group/launch config and elb Describe wrapper functions (avoids error when at least one resource requested does not exist in AWS) 

Logging errors with a logging package is more featureful and robust than doing so with print statements.