### PR TITLE
Public record set deleter

### DIFF
--- a/arn/arn.go
+++ b/arn/arn.go
@@ -367,6 +367,19 @@ func NamespaceForResource(t ResourceType) string {
 	return ""
 }
 
+// HostedZonePrefix is the string prefixing hostedzone IDs when retrieved from
+// the AWS API
+const HostedZonePrefix = "/hostedzone/"
+
+// SplitHostedZoneID splits a hosted zones' AWS ID, which might be prefixed with
+// "/hostedzone/", into the actual ID (the suffix)
+func SplitHostedZoneID(hzID string) ResourceName {
+	if hzSplit := strings.Split(hzID, HostedZonePrefix); len(hzSplit) == 2 && hzSplit[1] != "" {
+		hzID = hzSplit[1]
+	}
+	return ResourceName(hzID)
+}
+
 func getAutoScalingGroupARN(rn ResourceName) (string, error) {
 	if rn == "" {
 		return "", nil
@@ -602,11 +615,7 @@ func MapResourceTypeToARN(rt ResourceType, rn ResourceName, parsedEvents ...gjso
 		// arn:aws:route53:::change/changeid
 	case Route53HostedZoneRType:
 		// arn:aws:route53:::hostedzone/zoneid
-		hzSplit := strings.Split(rn.String(), "/hostedzone/")
-		if len(hzSplit) != 2 {
-			break
-		}
-		arn = fmt.Sprintf("%s:::hostedzone/%s", ARNPrefix, hzSplit[1])
+		arn = fmt.Sprintf("%s:::hostedzone/%s", ARNPrefix, SplitHostedZoneID(rn.String()))
 	case S3BucketRType:
 		// arn:aws:s3:::bucket-name
 		arn = fmt.Sprintf("%s:::%s", ARNPrefix, rn)

--- a/arn/arn_test.go
+++ b/arn/arn_test.go
@@ -252,9 +252,14 @@ func TestMapResourceTypeToARN(t *testing.T) {
 			InputName: "subscription-name",
 		},
 		{
-			Expected:  "arn:aws:route53:::hostedzone/zoneid",
+			Expected:  "arn:aws:route53:::hostedzone/zoneid-1",
 			InputType: Route53HostedZoneRType,
-			InputName: "/hostedzone/zoneid",
+			InputName: HostedZonePrefix + "zoneid-1",
+		},
+		{
+			Expected:  "arn:aws:route53:::hostedzone/zoneid-2",
+			InputType: Route53HostedZoneRType,
+			InputName: "zoneid-2",
 		},
 		{
 			Expected:  "arn:aws:s3:::bucket-name",


### PR DESCRIPTION
deleter: delete route53 record sets in public hosted zones
arn: hosted zone ID splitter helper function and const
cmd/grafiti: use hosted zone ID splitter

Route53 hosted zones configured for [split-horizon DNS](http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-private.html) will have mirrored resource record set entries in a public hosted zone, which should be cleaned up when deleting the complementary private hosted zone.