### PR TITLE
cronjob.yaml: Kubernetes CronJob config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,3 +383,87 @@ For example, if a tagged VPC has a user-created (non-default) subnet that is not
 ### Deleted resources report
 
 The `--report` flag will enable `grafiti delete` to aggregate all failed resource deletions and pretty-print them after a run. Log records of failed deletions will be saved as JSON objects in a log file in your current directory. Logging functionality uses the [logrus](https://github.com/sirupsen/logrus) package, which allows you to both create and parse log entries. However, because grafiti log entries are verbose, the logrus log parser might not function as expected. We recommend using `jq` to parse log data.
+
+## Deploying as a Kubernetes CronJob
+
+Kubernetes [CronJobs](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) schedule programs to run periodically or at a given point in time. Deploying grafiti to a Kubernetes allows you to clean your AWS account periodically, and aggregate and forward deletion logs. Creating and managing a grafiti CronJob can be made even easier using [Tectonic](https://coreos.com/tectonic/), CoreOS' self-driving Kubernetes software.
+
+### Setting up a CronJob
+
+1. Create a Kubernetes [CronJob config file](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/). Ensure container environments are provisioned with the following:
+    * Valid AWS credentials (environment variables or a 'credentials' file)
+    * A grafiti configuration file and/or environment variables
+    * Data or tag input files, depending on which sub-command you are running
+
+Example CronJob configuration file:
+```yaml
+apiVersion: batch/v2alpha1
+kind: CronJob
+metadata:
+  name: grafiti-deleter
+spec:
+  schedule: "* */6 * * *" # Run every 6 hours
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - command:
+            - /bin/bash
+            - -c
+            - grafiti -e -c /opt/config.toml delete -s --all-deps -f /opt/tags.json
+            env:
+              # Specify GRF_* environment variables here
+              - name: AWS_REGION
+                value: us-east-1
+              - name: AWS_CREDENTIAL_PROFILES_FILE # Sets the AWS 'credentials' file path
+                value: /etc/credentials
+            name: grafiti-deleter
+            image: your/registry/grafiti:v0.1.1
+            volumeMounts:
+              # Alternatively, add your own 'secret':
+              # https://kubernetes.io/docs/concepts/configuration/secret/
+              - mountPath: /etc/credentials # Mount a set of AWS credentials
+                name: grafiti-aws-credentials
+                readOnly: true
+              - mountPath: /opt/config.toml
+                name: config-path
+              - mountPath: /opt/tags.json
+                name: tags-path
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1000
+          volumes:
+            - hostPath:
+                path: ~/.aws/credentials # Specify location of AWS credentials you want to mount
+              name: grafiti-aws-credentials
+            - hostPath:
+                path: ./config.toml # Add your own config file path here
+              name: config-path
+            - hostPath:
+                path: ./example-tags-input.json # Add your own tag file path here
+              name: tags-path
+          restartPolicy: OnFailure
+```
+
+2. Run your Kubernetes API server with the `--runtime-config=batch/v2alpha1=true` flag to enable the CronJob API version. If you're using Tectonic, navigate to Console -> Workloads -> Daemon Sets -> YAML tab, and add a `- --runtime-config=batch/v2alpha1=true` field under the `containers.name:kube-apiserver.command` section.
+    * **Note**: updates to Kubernetes may cause this flag to be reset (see the Kubernetes [API versioning docs](https://kubernetes.io/docs/concepts/overview/kubernetes-api/#enabling-api-groups) for more information on enabling API versions). Tectonic does not recommend using non-default manifest file flags at the moment, but will support persistent changes to manifest files soon.
+
+3. Restart your API server. If you're using Tectonic, your API server pod will reload itself after clicking 'Save Changes'.
+
+4. [Set up and configure](https://coreos.com/tectonic/docs/latest/tutorials/first-app.html) `kubectl`.
+
+5. Follow the Kubernetes [documentation](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) to create your CronJob using `kubectl`. You're all set!
+
+Helpful Kubernetes documentation:
+ * Creating a [cluster](https://kubernetes.io/docs/getting-started-guides/aws/) in AWS
+ * [kubectl cheatsheet](https://kubernetes.io/docs/user-guide/kubectl-cheatsheet/)
+ * Creating a [secret](https://kubernetes.io/docs/concepts/configuration/secret/)
+
+Tectonic documentation:
+ * Creating a [cluster](https://coreos.com/tectonic/docs/latest/install/aws/index.html) in AWS
+ * Deploying an [application](https://coreos.com/tectonic/docs/latest/tutorials/first-app.html) on your cluster
+
+### Logging
+
+grafiti log files of the format `./delete-log-yyyy-mm-dd_HH-MM-SS.log` are created by each `grafiti delete` execution. The Kubernetes [logging architecture](https://kubernetes.io/docs/concepts/cluster-administration/logging/), which uses [fluentd](http://www.fluentd.org/) as its logging layer, can aggregate and forward log data from log files to an endpoint of your choices, like an S3 bucket.

--- a/cronjob.yaml
+++ b/cronjob.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v2alpha1
+kind: CronJob
+metadata:
+  name: grafiti-deleter
+spec:
+  schedule: "* */6 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - command:
+            - /bin/bash
+            - -c
+            - grafiti -e -c /opt/config.toml delete -s --all-deps -f /opt/tags.json
+            env:
+              - name: AWS_REGION
+                value: ${AWS_REGION}
+              - name: AWS_CREDENTIAL_PROFILES_FILE
+                value: /etc/credentials
+            name: grafiti-deleter
+            image: your/registry/grafiti:v0.1.1
+            volumeMounts:
+              - mountPath: /etc/credentials
+                name: grafiti-aws-credentials
+                readOnly: true
+              - mountPath: /opt/config.toml
+                name: config-path
+              - mountPath: /opt/tags.json
+                name: tags-path
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1000
+          volumes:
+            - hostPath:
+                path: ~/.aws/credentials
+              name: grafiti-aws-credentials
+            - hostPath:
+                path: ./config.toml
+              name: config-path
+            - hostPath:
+                path: ./example-tags-input.json
+              name: tags-path
+          restartPolicy: OnFailure


### PR DESCRIPTION
README.md: documented running grafiti CronJob using Kubernetes and Tectonic, log aggregation

Running grafiti as a Kubernetes CrobJob allows for log aggregation, scheduling, and AWS secret management

Fixes #33, #97 