### PR TITLE
cmd/grafiti: iteratively tag and request autoscaling resources, elb's

### DIFF
--- a/cmd/grafiti/tag_test.go
+++ b/cmd/grafiti/tag_test.go
@@ -300,9 +300,7 @@ func TestTagAutoScalingResource(t *testing.T) {
 	}
 
 	f := func(v interface{}, rt arn.ResourceType, rn arn.ResourceName, t Tags) {
-		rns := make(ResourceNameSet)
-		rns[rn] = t
-		tagAutoScalingResources(v.(autoscalingiface.AutoScalingAPI), rt, rns)
+		tagAutoScalingResources(v.(autoscalingiface.AutoScalingAPI), rt, rn, t)
 	}
 
 	for i, c := range cases {

--- a/deleter/deleter.go
+++ b/deleter/deleter.go
@@ -17,6 +17,12 @@ import (
 
 const drStr = "(dry-run)"
 
+// Error codes not defined by aws-sdk-go
+
+// ErrCodeValidationError is returned when a request did not conform to AWS API
+// backend expectations, ex. when a requested resource cannot be found
+const ErrCodeValidationError = "ValidationError"
+
 func setUpAWSSession() *session.Session {
 	maxRetries := viper.GetInt("maxNumRequestRetries")
 	return session.Must(session.NewSession(

--- a/deleter/elb.go
+++ b/deleter/elb.go
@@ -4,10 +4,16 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/elb/elbiface"
 	"github.com/coreos/grafiti/arn"
 )
+
+func isELBNotFoundError(err error) bool {
+	aerr, ok := err.(awserr.Error)
+	return ok && aerr.Code() == elb.ErrCodeAccessPointNotFoundException
+}
 
 // ElasticLoadBalancingLoadBalancerDeleter represents a collection of AWS elastic load balancers
 type ElasticLoadBalancingLoadBalancerDeleter struct {
@@ -82,14 +88,13 @@ func (rd *ElasticLoadBalancingLoadBalancerDeleter) RequestElasticLoadBalancers()
 		return nil, nil
 	}
 
-	size, chunk := len(rd.ResourceNames), 20
-	elbs := make([]*elb.LoadBalancerDescription, 0)
-	var err error
-	// Can only filter in batches of 20
-	for i := 0; i < size; i += chunk {
-		stop := CalcChunk(i, size, chunk)
-		elbs, err = rd.requestElasticLoadBalancers(rd.ResourceNames[i:stop], elbs)
-		if err != nil {
+	var elbs []*elb.LoadBalancerDescription
+	// Requesting a batch of resources that contains at least one already deleted
+	// resource will return an error and no resources. To guard against this,
+	// request them one by one
+	for _, name := range rd.ResourceNames {
+		var err error
+		if elbs, err = rd.requestElasticLoadBalancer(name, elbs); err != nil && !isELBNotFoundError(err) {
 			return elbs, err
 		}
 	}
@@ -97,30 +102,19 @@ func (rd *ElasticLoadBalancingLoadBalancerDeleter) RequestElasticLoadBalancers()
 	return elbs, nil
 }
 
-// Requesting elastic load balancers using filters prevents API errors caused by
-// requesting non-existent elastic load balancers
-func (rd *ElasticLoadBalancingLoadBalancerDeleter) requestElasticLoadBalancers(chunk arn.ResourceNames, elbs []*elb.LoadBalancerDescription) ([]*elb.LoadBalancerDescription, error) {
+func (rd *ElasticLoadBalancingLoadBalancerDeleter) requestElasticLoadBalancer(rn arn.ResourceName, elbs []*elb.LoadBalancerDescription) ([]*elb.LoadBalancerDescription, error) {
 	params := &elb.DescribeLoadBalancersInput{
-		LoadBalancerNames: chunk.AWSStringSlice(),
-		PageSize:          aws.Int64(50),
+		LoadBalancerNames: []*string{rn.AWSString()},
 	}
 
-	for {
-		ctx := aws.BackgroundContext()
-		resp, err := rd.GetClient().DescribeLoadBalancersWithContext(ctx, params)
-		if err != nil {
-			fmt.Printf("{\"error\": \"%s\"}\n", err)
-			return elbs, err
-		}
-
-		elbs = append(elbs, resp.LoadBalancerDescriptions...)
-
-		if aws.StringValue(resp.NextMarker) == "" {
-			break
-		}
-
-		params.Marker = resp.NextMarker
+	ctx := aws.BackgroundContext()
+	resp, err := rd.GetClient().DescribeLoadBalancersWithContext(ctx, params)
+	if err != nil {
+		fmt.Printf("{\"error\": \"%s\"}\n", err)
+		return elbs, err
 	}
+
+	elbs = append(elbs, resp.LoadBalancerDescriptions...)
 
 	return elbs, nil
 }


### PR DESCRIPTION
cmd/grafiti: iteratively tag autoscaling groups

deleter: iteratively request ELBs and AutoScaling resources to prevent AWS errors, and elide specific errors relating to resources not found

Prevents AWS from returning an error when attempting to tag or request a batch of resources that contain at least one non-existent resource and not performing the desired action.