### PR TITLE
cmd: comprehensive, configurable logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ tagPatterns = [
 filterPatterns = [
   ".TaggingMetadata.ResourceType == \"AWS::EC2::Instance\""
 ]
+logDir = "/var/log"
 ```
 
  * `resourceTypes` - Specifies a list of resource types to query for. These can be any values the CloudTrail [API](http://docs.aws.amazon.com/awscloudtrail/latest/userguide/view-cloudtrail-events-supported-resource-types.html), or CloudTrail [log files](http://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-supported-services.html) if you're parsing files from a CloudTrail S3 bucket, accept.
@@ -110,6 +111,7 @@ filterPatterns = [
  * `includeEvent` - Setting `true` will include the raw CloudEvent in the tagging output (this is useful for finding attributes to filter on).
  * `tagPatterns` - should use `jq` syntax to generate `{tagKey: tagValue}` objects from output from `grafiti parse`. The results will be included in the `Tags` field of the tagging output.
  * `filterPatterns` - will filter output of `grafiti parse` based on `jq` syntax matches.
+ * `logDir` - By default, grafiti logs to stderr. If this field is present in your config, grafiti writes logs to a file in this directory. Log files have the format: 'grafiti-yyyymmdd_HHMMSS.log'.
 
 ### Environment variables
 
@@ -303,7 +305,6 @@ tagPatterns = [
 filterPatterns = [
   ".TaggingMetadata.ResourceType == \"AWS::EC2::Instance\"",
 ]
-
 ```
 
 Run:
@@ -451,8 +452,10 @@ Tectonic documentation:
 
 ### Logging
 
-grafiti log files of the format `./delete-log-yyyy-mm-dd_HH-MM-SS.log` are created by each `grafiti delete` execution. The Kubernetes [logging architecture](https://kubernetes.io/docs/concepts/cluster-administration/logging/), which uses [fluentd](http://www.fluentd.org/) as its logging layer, can aggregate and forward log data from log files to an endpoint of your choices, like an S3 bucket.
+Grafiti supports two forms of logging: to a file or stderr. Logs are sent to stderr by default, and to a log file if the `logDir` config field (`GRF_LOG_DIR` environment variable) is not empty. In the latter case, grafiti log files of the format `grafiti-yyyymmdd_HHMMSS.log` are created by each `grafiti` execution. The Kubernetes [logging architecture][kubernetes-logging], which uses [fluentd][fluentd-website] as its logging layer, can aggregate and forward log data from log files to an endpoint of your choices, like an S3 bucket.
 
 [aws-configure]: http://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html
 [aws-configure-region]: http://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-the-region
 [aws-configure-credentials]: http://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+[kubernetes-logging]: https://kubernetes.io/docs/concepts/cluster-administration/logging/
+[fluentd-website]: http://www.fluentd.org/

--- a/arn/arn.go
+++ b/arn/arn.go
@@ -638,11 +638,7 @@ func MapARNToRTypeAndRName(arnStr ResourceARN) (ResourceType, ResourceName) {
 	var sfx string
 	switch {
 	case strings.HasPrefix(arn, "arn:aws:autoscaling:"):
-		erASG, err := re.Compile("arn:aws:autoscaling:[^:]+:[^:]+:(.+)")
-		if err != nil {
-			fmt.Printf("{\"error\": \"%s\"}\n", err.Error())
-			break
-		}
+		erASG := re.MustCompile("arn:aws:autoscaling:[^:]+:[^:]+:(.+)")
 		m := erASG.FindStringSubmatch(arn)
 		if len(m) == 2 {
 			sfx = m[1]
@@ -657,11 +653,7 @@ func MapARNToRTypeAndRName(arnStr ResourceARN) (ResourceType, ResourceName) {
 		}
 
 	case strings.HasPrefix(arn, "arn:aws:ec2:"):
-		erEC2, err := re.Compile("arn:aws:ec2:[^:]+:(?:[^:]+:)?(.+)")
-		if err != nil {
-			fmt.Printf("{\"error\": \"%s\"}\n", err.Error())
-			break
-		}
+		erEC2 := re.MustCompile("arn:aws:ec2:[^:]+:(?:[^:]+:)?(.+)")
 		m := erEC2.FindStringSubmatch(arn)
 		if len(m) == 2 {
 			sfx = m[1]
@@ -699,11 +691,7 @@ func MapARNToRTypeAndRName(arnStr ResourceARN) (ResourceType, ResourceName) {
 		return ElasticLoadBalancingLoadBalancerRType, arnToID("loadbalancer/", arn)
 
 	case strings.HasPrefix(arn, "arn:aws:iam::"):
-		erIAM, err := re.Compile("arn:aws:iam::[^:]+:(.+)")
-		if err != nil {
-			fmt.Printf("{\"error\": \"%s\"}\n", err.Error())
-			break
-		}
+		erIAM := re.MustCompile("arn:aws:iam::[^:]+:(.+)")
 		m := erIAM.FindStringSubmatch(arn)
 		if len(m) == 2 {
 			sfx = m[1]

--- a/cmd/grafiti/filter_test.go
+++ b/cmd/grafiti/filter_test.go
@@ -45,6 +45,8 @@ func captureFilterStdOut(f func(rgtaiface.ResourceGroupsTaggingAPIAPI, io.Reader
 
 	// Execute any f that takes an interface{} argument
 	if err := f(svc, v1, v2); err != nil {
+		w.Close()
+		os.Stdout = oldStdOut
 		return "", err
 	}
 

--- a/cmd/grafiti/main.go
+++ b/cmd/grafiti/main.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -35,6 +37,7 @@ var (
 
 // Grafiti-specific environment variables are prefixed with GRF_
 var envVarMap = map[string]string{
+	"GRF_LOG_DIR":         "logDir",
 	"GRF_START_HOUR":      "startHour",
 	"GRF_END_HOUR":        "endHour",
 	"GRF_START_TIMESTAMP": "startTimeStamp",
@@ -49,6 +52,62 @@ const errExit = 1
 func exitWithError(err error) {
 	fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 	os.Exit(errExit)
+}
+
+// RequestLogger holds a logger and its log file, if any.
+type RequestLogger struct {
+	logrus.Logger
+	LogFile string
+}
+
+// Global logger for 'main' package. Passed as 'logger' to Deleters in a
+// DeleteConfig.
+var logger = &RequestLogger{
+	Logger: logrus.Logger{
+		Out:       os.Stderr,
+		Formatter: &logrus.JSONFormatter{},
+		Level:     logrus.InfoLevel,
+	},
+}
+
+// initRequestLogger creates a logrus.FieldLogger that logs to a file in logDir,
+// or os.Stderr if logDir is not specified or cannot be opened. File format:
+// 'grafiti-yyyymmdd_HHMMSS.log'
+func (l *RequestLogger) initRequestLogger() {
+	if l == nil {
+		l = &RequestLogger{
+			Logger: logrus.Logger{
+				Out:       os.Stderr,
+				Formatter: &logrus.JSONFormatter{},
+				Level:     logrus.InfoLevel,
+			},
+		}
+	}
+
+	// debug flag sets log level to "debug"
+	if debug {
+		l.Level = logrus.DebugLevel
+	}
+	l.Infof("using log level '%s'", l.Level)
+
+	// Log file path. RequestLogger logs to stderr if dir is empty.
+	var fp string
+	dir := viper.GetString("logDir")
+	if dir != "" {
+		// Create log file in dir
+		t := time.Now()
+		fp = filepath.Join(dir, fmt.Sprintf("grafiti-%d%02d%02d_%02d%02d%02d.log", t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second()))
+		f, err := os.OpenFile(fp, os.O_CREATE|os.O_WRONLY, 0664)
+		if err != nil {
+			l.Errorln("open log file:", err)
+		} else {
+			l.Infof("logging to file: %s", fp)
+			l.Out = f
+			l.LogFile = fp
+		}
+	} else {
+		l.Infof("logging to stderr")
+	}
 }
 
 // RootCmd represents the base command when called without any subcommands
@@ -67,7 +126,7 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	// Root config holds global config
-	RootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "Config file (default: $HOME/.grafiti.toml)")
+	RootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "Config file (default: $HOME/.grafiti.toml).")
 	RootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Enable debug logging.")
 	RootCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "Output changes to stdout instead of AWS.")
 	RootCmd.PersistentFlags().BoolVarP(&ignoreErrors, "ignore-errors", "e", false, "Continue processing even when there are API errors.")
@@ -108,7 +167,9 @@ func initConfig() {
 			exitWithError(fmt.Errorf("read config file: %s", err))
 		}
 	} else {
-		logrus.Infoln("Using config file:", viper.ConfigFileUsed())
+		logger.Infoln("Using config file:", viper.ConfigFileUsed())
+		// Initialize global logger after reading config file in case 'logDir' is set
+		logger.initRequestLogger()
 		return
 	}
 
@@ -118,7 +179,10 @@ func initConfig() {
 	if err := viper.ReadConfig(bytes.NewBuffer([]byte(""))); err != nil {
 		exitWithError(fmt.Errorf("read dummy config file: %s", err))
 	} else {
-		logrus.Info("Using environment variables to configure grafiti.")
+		logger.Info("Using environment variables to configure grafiti.")
+		// Initialize global logger after reading config file in case 'GRF_LOG_DIR'
+		// is set
+		logger.initRequestLogger()
 		return
 	}
 }

--- a/cmd/grafiti/parse_test.go
+++ b/cmd/grafiti/parse_test.go
@@ -159,7 +159,6 @@ func TestParseCloudTrailEvent(t *testing.T) {
 			gotStr += parseRawCloudTrailEvent(string(event)) + "\n"
 		}
 
-		// NOTE: non-deterministic pass. jq eval will occasionally fail for some reason.
 		if string(want) != gotStr {
 			t.Errorf("printCloudTrailEvent case %d failed\nwanted\n%s\n\ngot\n%s\n", i+1, string(want), gotStr)
 		}
@@ -183,7 +182,7 @@ func captureStdOut(f func(interface{}), v interface{}) string {
 		pipeOut <- buf.String()
 	}()
 
-	// Execute any f that takes an interface{} argument
+	// Capture stdout of any f that prints to stdout
 	f(v)
 
 	w.Close()
@@ -222,7 +221,6 @@ func TestPrintCloudTrailEvents(t *testing.T) {
 			t.Fatal("Failed to open", c.ExpectedFile)
 		}
 
-		// NOTE: non-deterministic pass. jq eval will occasionally fail for some reason.
 		if string(want) != ctJSON {
 			t.Errorf("printCloudTrailEvent case %d failed\nwanted\n%s\n\ngot\n%s\n", i+1, string(want), ctJSON)
 		}

--- a/config.toml
+++ b/config.toml
@@ -16,3 +16,4 @@ filterPatterns = [
   # ".TaggingMetadata.ResourceType == \"AWS::EC2::Instance\"",
   # ".TaggingMetadata.ResourceType == \"AWS::ElasticLoadBalancing::LoadBalancer\"",
 ]
+logDir = "/tmp"

--- a/deleter/deleter.go
+++ b/deleter/deleter.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -45,25 +44,6 @@ type DeleteConfig struct {
 	DryRun       bool
 	IgnoreErrors bool
 	Logger       logrus.FieldLogger
-}
-
-// InitRequestLogger creates a logrus.FieldLogger that logs to a file at path,
-// or os.Stdout if an error occurs opening the file
-func InitRequestLogger(path string) logrus.FieldLogger {
-	logger := &logrus.Logger{
-		Out:       os.Stdout,
-		Formatter: &logrus.JSONFormatter{},
-		Level:     logrus.InfoLevel,
-	}
-
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0664)
-	if err == nil {
-		logger.Out = f
-	} else {
-		logger.Infof("Failed to open file %s for logging, using stdout instead", path)
-	}
-
-	return logger
 }
 
 // LogEntry maps potential log entry fields to a Go struct. Add fields here when

--- a/testdata/config/test-config.toml
+++ b/testdata/config/test-config.toml
@@ -16,3 +16,4 @@ filterPatterns = [
   # ".TaggingMetadata.ResourceType == \"AWS::EC2::Instance\"",
   # ".TaggingMetadata.ResourceType == \"AWS::ElasticLoadBalancing::LoadBalancer\"",
 ]
+# logDir = "/tmp"


### PR DESCRIPTION
cmd: comprehensive, configurable logging in package `main`, and pass logger object to `deleter` via `DeleteConfig`

Grafiti error reporting needs to be more verbose and configurable. Errors are now at least logged if not returned and handled by callers.

Fixes #107 