### PR TITLE
arn: UntaggableResourceTypes for resources that can't be tagged

### DIFF
--- a/arn/arn.go
+++ b/arn/arn.go
@@ -314,17 +314,21 @@ const (
 	S3Namespace = "s3"
 )
 
-// CTUnsupportedResourceTypes holds values for which CloudTrail does not
-// collect logs
+// CTUnsupportedResourceTypes holds ResourceTypes of resources from which the
+// CloudTrail API does not collect logs
 var CTUnsupportedResourceTypes = map[ResourceType]struct{}{
 	Route53HostedZoneRType: struct{}{},
 }
 
-// RGTAUnsupportedResourceTypes holds values the Resource Group Tagging
-// API does not support
+// RGTAUnsupportedResourceTypes holds ResourceTypes of resources that the
+// Resource Group Tagging API does not support
 var RGTAUnsupportedResourceTypes = map[ResourceType]struct{}{
-	Route53HostedZoneRType:              struct{}{},
-	AutoScalingGroupRType:               struct{}{},
+	Route53HostedZoneRType: struct{}{},
+	AutoScalingGroupRType:  struct{}{},
+}
+
+// UntaggableResourceTypes holds ResourceTypes of resources that cannot be tagged
+var UntaggableResourceTypes = map[ResourceType]struct{}{
 	AutoScalingLaunchConfigurationRType: struct{}{},
 	AutoScalingPolicyRType:              struct{}{},
 	AutoScalingScheduledActionRType:     struct{}{},

--- a/cmd/grafiti/tag.go
+++ b/cmd/grafiti/tag.go
@@ -278,6 +278,11 @@ func tag(reader io.Reader) error {
 		// Check map that holds all RGTA-unsupported resource types and bucket
 		// accordingly
 		tm := t.TaggingMetadata
+		// Certain resources do not support tagging at all. Skip these.
+		if _, ok := arn.UntaggableResourceTypes[tm.ResourceType]; ok {
+			continue
+		}
+
 		if tm.ResourceType != "" && tm.ResourceName != "" && tm.ResourceARN != "" {
 			if _, ok := arn.RGTAUnsupportedResourceTypes[tm.ResourceType]; ok {
 				resourceNameBuckets.AddResourceNameToBucket(tm.ResourceType, tm.ResourceName, t.Tags)


### PR DESCRIPTION
arn: UntaggableResourceTypes for resources that can't be tagged

Created `UntaggableResourceTypes` for resources that can't be tagged, rather than conflate them with resources that are taggable but unsupported by the RGTA. Useful when iterating over [`RGTAUnsupportedResourceTypes`](https://github.com/coreos/grafiti/blob/master/cmd/grafiti/delete.go#L145).