### PR TITLE
*: remove silent flag and delete output

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ spec:
           - command:
             - /bin/bash
             - -c
-            - grafiti -e -c /opt/config.toml delete -s --all-deps -f /opt/tags.json
+            - grafiti -e -c /opt/config.toml delete --all-deps -f /opt/tags.json
             env:
               # Specify GRF_* environment variables here
               - name: AWS_REGION

--- a/cmd/grafiti/delete.go
+++ b/cmd/grafiti/delete.go
@@ -39,7 +39,6 @@ import (
 
 var (
 	deleteFile string
-	silent     bool
 	delAllDeps bool
 	wantReport bool
 )
@@ -80,7 +79,6 @@ type TagFileInput struct {
 func init() {
 	RootCmd.AddCommand(deleteCmd)
 	deleteCmd.PersistentFlags().StringVarP(&deleteFile, "delete-file", "f", "", "File of tags of resources to delete.")
-	deleteCmd.PersistentFlags().BoolVarP(&silent, "silent", "s", false, "Suppress JSON output.")
 	deleteCmd.PersistentFlags().BoolVar(&delAllDeps, "all-deps", false, "Delete all dependencies of all tagged resourcs.")
 	deleteCmd.PersistentFlags().BoolVar(&wantReport, "report", false, "Pretty-print a report of resource deletion errors, if any.")
 }
@@ -149,16 +147,7 @@ func deleteFromTags(reader io.Reader) error {
 	}
 
 	// Delete batch of matching resources
-	if err := deleteARNs(allARNs); err != nil {
-		return err
-	}
-
-	if !silent {
-		arnsJSON, _ := json.MarshalIndent(allARNs, "", " ")
-		fmt.Printf("{\"DeletedARNs\": %s}\n", arnsJSON)
-	}
-
-	return nil
+	return deleteARNs(allARNs)
 }
 
 func getARNsForResource(svc rgtaiface.ResourceGroupsTaggingAPIAPI, tags []*rgta.TagFilter, arnList arn.ResourceARNs) arn.ResourceARNs {

--- a/cronjob.yaml
+++ b/cronjob.yaml
@@ -12,7 +12,7 @@ spec:
           - command:
             - /bin/bash
             - -c
-            - grafiti -e -c /opt/config.toml delete -s --all-deps -f /opt/tags.json
+            - grafiti -e -c /opt/config.toml delete --all-deps -f /opt/tags.json
             env:
               - name: AWS_REGION
                 value: ${AWS_REGION}


### PR DESCRIPTION
*: remove `--silent` flag and printing of deleted ARNs in `grafiti delete`

Grafiti will soon [log all errors and output](https://github.com/coreos/grafiti/pull/111), thus `grafiti delete` sending a JSON object of (potentially) deleted resource ARNs is redundant. The `--silent` flag was only around to suppress this, so that is removed as well.