### PR TITLE
cmd/grafiti: exit cmd on error gracefully

### DIFF
--- a/cmd/grafiti/delete.go
+++ b/cmd/grafiti/delete.go
@@ -84,26 +84,36 @@ func init() {
 }
 
 var deleteCmd = &cobra.Command{
-	Use:   "delete",
-	Short: "Delete resources in AWS by tag.",
-	Long:  "Delete resources in AWS by tags specified in 'delete-file'.",
-	RunE:  runDeleteCommand,
+	Use:           "delete",
+	Short:         "Delete resources in AWS by tag.",
+	Long:          "Delete resources in AWS by tags specified in 'delete-file'.",
+	RunE:          runDeleteCommand,
+	SilenceErrors: true,
+	SilenceUsage:  true,
 }
 
 func runDeleteCommand(cmd *cobra.Command, args []string) error {
+	// We decode tags from deleteFile that resources `grafiti delete` should
+	// delete are tagged with.
 	if deleteFile != "" {
-		return deleteFromFile(deleteFile)
+		if err := deleteFromFile(deleteFile); err != nil {
+			return fmt.Errorf("delete: %s", err)
+		}
+		return nil
 	}
+
+	// Same data as that in deleteFile but passed by stdin.
 	if err := deleteFromStdIn(); err != nil {
-		return err
+		return fmt.Errorf("delete: %s", err)
 	}
+
 	return nil
 }
 
 func deleteFromFile(fname string) error {
 	file, err := os.Open(fname)
 	if err != nil {
-		return err
+		return fmt.Errorf("open delete file: %s", err)
 	}
 	defer file.Close()
 

--- a/cmd/grafiti/main.go
+++ b/cmd/grafiti/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -42,12 +43,24 @@ var envVarMap = map[string]string{
 	"GRF_INCLUDE_EVENT":   "includeEvent",
 }
 
+// http://tldp.org/LDP/abs/html/exitcodes.html
+const errExit = 1
+
+func exitWithError(err error) {
+	fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+	os.Exit(errExit)
+}
+
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:   "grafiti",
 	Short: "Ingest CloudTrail data to tag, then delete, AWS resources.",
 	Long:  `Parse resources ID's from CloudTrail events to tag them in AWS, then delete them later.`,
-	Run:   func(cmd *cobra.Command, args []string) { cmd.Usage() },
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return errors.New("no sub-command provided. See `grafiti --help` for information")
+	},
+	SilenceErrors: true,
+	SilenceUsage:  true,
 }
 
 func init() {
@@ -62,10 +75,9 @@ func init() {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
-	// Check for 'jq' in path
+	// Ensure jq is installed and in $PATH
 	if path, err := exec.LookPath("jq"); err != nil || path == "" {
-		fmt.Println("Please install 'jq' before running grafiti.")
-		os.Exit(1)
+		exitWithError(errors.New("'jq' must be installed before running grafiti"))
 	}
 
 	if cfgFile != "" { // enable ability to specify config file via flag
@@ -93,8 +105,7 @@ func initConfig() {
 		// wants to solely use env vars to configure grafiti if no config file was
 		// provided
 		if cfgFile != "" {
-			logrus.Errorln("read config file:", err)
-			os.Exit(1)
+			exitWithError(fmt.Errorf("read config file: %s", err))
 		}
 	} else {
 		logrus.Infoln("Using config file:", viper.ConfigFileUsed())
@@ -105,8 +116,7 @@ func initConfig() {
 	// environment variables
 	viper.SetConfigType("toml")
 	if err := viper.ReadConfig(bytes.NewBuffer([]byte(""))); err != nil {
-		logrus.Errorln("read dummy config file:", err)
-		os.Exit(1)
+		exitWithError(fmt.Errorf("read dummy config file: %s", err))
 	} else {
 		logrus.Info("Using environment variables to configure grafiti.")
 		return
@@ -115,6 +125,6 @@ func initConfig() {
 
 func main() {
 	if err := RootCmd.Execute(); err != nil {
-		os.Exit(-1)
+		exitWithError(err)
 	}
 }

--- a/cmd/grafiti/tag.go
+++ b/cmd/grafiti/tag.go
@@ -224,19 +224,28 @@ func init() {
 }
 
 var tagCmd = &cobra.Command{
-	Use:   "tag",
-	Short: "Tag resources in AWS.",
-	Long:  "Tag resources in AWS using tags created by the 'parse' subcommand.",
-	RunE:  runTagCommand,
+	Use:           "tag",
+	Short:         "Tag resources in AWS.",
+	Long:          "Tag resources in AWS using tags created by the 'parse' subcommand.",
+	RunE:          runTagCommand,
+	SilenceErrors: true,
+	SilenceUsage:  true,
 }
 
 func runTagCommand(cmd *cobra.Command, args []string) error {
+	// tagFile holds data structured in the output format of `grafiti parse`.
 	if tagFile != "" {
-		return tagFromFile(tagFile)
+		if err := tagFromFile(tagFile); err != nil {
+			return fmt.Errorf("tag: %s", err)
+		}
+		return nil
 	}
+
+	// Same data as that in tagFile but passed by stdin.
 	if err := tagFromStdIn(); err != nil {
-		return err
+		return fmt.Errorf("tag: %s", err)
 	}
+
 	return nil
 }
 

--- a/cmd/grafiti/tag_test.go
+++ b/cmd/grafiti/tag_test.go
@@ -162,8 +162,8 @@ func TestAddResourceNameToBucket(t *testing.T) {
 // Set stdout to pipe and capture printed output of a Print event
 func captureRGTAStdOut(f func(rgtaiface.ResourceGroupsTaggingAPIAPI, arn.ResourceARNs, Tag) error, i rgtaiface.ResourceGroupsTaggingAPIAPI, as arn.ResourceARNs, t Tag) string {
 	oldStdOut := os.Stdout
-	r, w, perr := os.Pipe()
-	if perr != nil {
+	r, w, err := os.Pipe()
+	if err != nil {
 		return ""
 	}
 
@@ -244,8 +244,8 @@ func TestTagARNBucket(t *testing.T) {
 // Set stdout to pipe and capture printed output of a Print event
 func captureRGTAUnsupportedStdOut(f func(interface{}, arn.ResourceType, arn.ResourceName, Tags), i interface{}, rt arn.ResourceType, rn arn.ResourceName, t Tags) string {
 	oldStdOut := os.Stdout
-	r, w, perr := os.Pipe()
-	if perr != nil {
+	r, w, err := os.Pipe()
+	if err != nil {
 		return ""
 	}
 
@@ -453,17 +453,17 @@ func TestDecodeInput(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		f, ferr := os.Open(c.InputFilePath)
-		if ferr != nil {
+		f, err := os.Open(c.InputFilePath)
+		if err != nil {
 			t.Fatal("Failed to open", c.InputFilePath)
 		}
 		defer f.Close()
 
 		dec := json.NewDecoder(bufio.NewReader(f))
 		for i := 0; ; i++ {
-			ti, isEOF, derr := decodeInput(dec)
-			if derr != nil {
-				t.Fatal("Failed to decode:", derr.Error())
+			ti, isEOF, err := decodeInput(dec)
+			if err != nil {
+				t.Fatal("Failed to decode:", err.Error())
 			}
 			if isEOF {
 				break


### PR DESCRIPTION
cmd/grafiti: exit `grafiti` and sub-commands gracefully when errors occur

exitWithError and exitSuccess wrap os.Exit to manage cmd exit gracefully rather than cobra handle errors by printing help text.