### PR TITLE
Makefile: add code check, clean, release, test targets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*
+!_output/bin

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 # Folders
 _obj
 _test
+_output
+bin
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,12 @@
-FROM golang:1.8.3-alpine
+FROM alpine:3.5
 MAINTAINER Eric Stroczynski <eric.stroczynski@coreos.com>
 
-ENV GRAFITI_ABS_PATH ${GOPATH}/src/github.com/coreos/grafiti
+# Utils a user might need while running grafiti in a container
+RUN apk add --no-cache jq
 
-COPY . ${GRAFITI_ABS_PATH}/
+# Copy built binary into image
+COPY _output/bin/grafiti /usr/local/bin/grafiti
 
-# Install grafiti, build utils, and jq
-RUN set -eux \
-    && apk add --no-cache jq make glide bash \
-    && apk add --no-cache --virtual .build-deps git \
-    && cd ${GRAFITI_ABS_PATH} \
-    && make install \
-    && apk del .build-deps
+WORKDIR /
 
-# Jenkins starts the docker image as uid 1000. `/go` needs to be writable for
-# this user. This gives permissions to all users to the `/go` folder like it is
-# done in the upstream golang docker image.
-RUN chmod 777 -R /go
+CMD ["grafiti", "--help"]

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,78 @@
-GRAFITI_REL_PATH ?= github.com/coreos/grafiti
-INSTALL_PATH = $(GRAFITI_REL_PATH)/cmd/grafiti
+PROJ=grafiti
+ORG_PATH=github.com/coreos
+REPO_PATH=$(ORG_PATH)/$(PROJ)
+INSTALL_PATH=$(REPO_PATH)/cmd/grafiti
+export PATH := $(PWD)/bin:$(PATH)
 
-all: build test
+VERSION ?= $(shell ./scripts/git-version)
 
-build:
-	go build -a -o grafiti $(INSTALL_PATH)
+DOCKER_REPO=quay.io/coreos/grafiti
+DOCKER_IMAGE=$(DOCKER_REPO):$(VERSION)
+
+$(	shell mkdir -p bin	)
+$(	shell mkdir -p _output/images	)
+$(	shell mkdir -p _output/bin	)
+
+user=$(shell id -u -n)
+group=$(shell id -g -n)
+
+export GOBIN=$(PWD)/bin
+
+LD_FLAGS="-w -X $(REPO_PATH)/version.Version=$(VERSION)"
+
+build: bin/grafiti
+
+bin/grafiti:
+	@go install -v -ldflags $(LD_FLAGS) $(INSTALL_PATH)
 
 install:
-	go install $(INSTALL_PATH)
+	@GOBIN=$(GOPATH)/bin go install -v -ldflags $(LD_FLAGS) $(INSTALL_PATH)
+
+.PHONY: release-binary
+release-binary:
+	@go build -o /go/bin/grafiti -v -ldflags $(LD_FLAGS) $(INSTALL_PATH)
+
+.PHONY: revendor
+revendor:
+	@glide up -v
+	@glide-vc --use-lock-file --no-tests --only-code
 
 test:
-	go test -v $(shell glide novendor)
+	@go test -v -i $(shell go list ./... | grep -v '/vendor/')
+	@go test -v $(shell go list ./... | grep -v '/vendor/')
+
+testrace:
+	@go test -v -i --race $(shell go list ./... | grep -v '/vendor/')
+	@go test -v --race $(shell go list ./... | grep -v '/vendor/')
+
+vet:
+	@go vet $(shell go list ./... | grep -v '/vendor/')
+
+fmt:
+	@go fmt $(shell go list ./... | grep -v '/vendor/')
 
 lint:
-	go fmt $(shell glide novendor)
+	@for package in $(shell go list ./... | grep -v '/vendor/' | grep -v '/api' | grep -v '/server/internal'); do \
+      golint -set_exit_status $$package $$i || exit 1; \
+	done
 
-clean:
-	go clean
+_output/bin/grafiti:
+	@./scripts/docker-build
+	@sudo chown $(user):$(group) _output/bin/grafiti
 
-.PHONY: all install build test lint clean
+.PHONY: docker-image
+docker-image: clean-release _output/bin/grafiti
+	@sudo docker build -t $(DOCKER_IMAGE) .
+
+clean: clean-release
+	@rm -rf bin/
+
+.PHONY: clean-release
+clean-release:
+	@rm -rf _output/
+
+testall: testrace vet fmt lint
+
+FORCE:
+
+.PHONY: build install test testrace vet fmt lint testall

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+
+mkdir -p _output/bin
+
+sudo docker run \
+  --cidfile=cid \
+  -v "$PWD":/go/src/github.com/coreos/grafiti:ro \
+  -w /go/src/github.com/coreos/grafiti \
+  golang:1.8.3-alpine \
+  /bin/sh -x -c \
+  'apk add --no-cache --update alpine-sdk && make release-binary'
+
+sudo docker cp "$(cat cid)":/go/bin/grafiti _output/bin/grafiti
+sudo docker rm "$(cat cid)"
+sudo rm cid

--- a/scripts/docker-test
+++ b/scripts/docker-test
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+# Using golang:X.X.X-stretch because `go test` does not work as expected in
+# 'golang:1.8.3-alpine'
+sudo docker run \
+  -v "$PWD":/go/src/github.com/coreos/grafiti \
+  -w /go/src/github.com/coreos/grafiti \
+  -e AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
+  -e AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+  golang:1.8.3-stretch \
+  /bin/bash -x -c \
+  'apt-get update && apt-get install -y jq \
+  && go get -u github.com/golang/lint/golint \
+  && make testall'

--- a/scripts/git-version
+++ b/scripts/git-version
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+
+# Parse the current git commit hash
+COMMIT="$(git rev-parse HEAD)"
+
+# Check if the current commit has a matching tag
+TAG=$(git describe --exact-match --abbrev=0 --tags "$COMMIT" 2> /dev/null || true)
+
+# Use the matching tag as the version, if available
+if [ -z "$TAG" ]; then
+  VERSION="$COMMIT"
+else
+  VERSION="$TAG"
+fi
+
+# Check for changed files (not untracked files)
+if [ -n "$(git diff --shortstat 2> /dev/null | tail -n1)" ]; then
+  VERSION="${VERSION}-dirty"
+fi
+
+echo "$VERSION"


### PR DESCRIPTION
Makefile: add targets related to formatting code, cleaning, release, and testing
scripts: bash scripts to get git version and build docker images
.gitignore: ignore build directories `_output` and `bin`
Jenkinsfile: new test target `testall` used to test grafiti

These Makefile updates give a much greater range of 1-command power to grafiti users and developers. Modeled after [dex's Makefile](https://github.com/coreos/dex/blob/5582232a03b0ba9e40756709aa53964da89e90e7/Makefile) and [scripts](https://github.com/coreos/dex/blob/5582232a03b0ba9e40756709aa53964da89e90e7/scripts).