### PR TITLE
*: remove region config key in favor of AWS_REGION

### DIFF
--- a/arn/arn.go
+++ b/arn/arn.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
-	"github.com/spf13/viper"
 	"github.com/tidwall/gjson"
 )
 
@@ -390,9 +389,7 @@ func getAutoScalingGroupARN(rn ResourceName) (string, error) {
 	}
 
 	svc := autoscaling.New(session.Must(session.NewSession(
-		&aws.Config{
-			Region: aws.String(viper.GetString("region")),
-		},
+		&aws.Config{},
 	)))
 	params := &autoscaling.DescribeAutoScalingGroupsInput{
 		AutoScalingGroupNames: aws.StringSlice([]string{rn.String()}),

--- a/cmd/grafiti/delete.go
+++ b/cmd/grafiti/delete.go
@@ -131,9 +131,7 @@ func deleteFromTags(reader io.Reader) error {
 	allARNs := make(arn.ResourceARNs, 0)
 
 	svc := rgta.New(session.Must(session.NewSession(
-		&aws.Config{
-			Region: aws.String(viper.GetString("region")),
-		},
+		&aws.Config{},
 	)))
 
 	for {
@@ -212,9 +210,7 @@ func getARNsForResource(svc rgtaiface.ResourceGroupsTaggingAPIAPI, tags []*rgta.
 
 func getARNsForUnsupportedResource(rt arn.ResourceType, tags []*rgta.TagFilter, arnList arn.ResourceARNs) arn.ResourceARNs {
 	sess := session.Must(session.NewSession(
-		&aws.Config{
-			Region: aws.String(viper.GetString("region")),
-		},
+		&aws.Config{},
 	))
 
 	switch arn.NamespaceForResource(rt) {

--- a/cmd/grafiti/filter.go
+++ b/cmd/grafiti/filter.go
@@ -13,7 +13,6 @@ import (
 	rgtaiface "github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface"
 	"github.com/coreos/grafiti/arn"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -50,9 +49,7 @@ func runFilterCommand(cmd *cobra.Command, args []string) error {
 	defer iFile.Close()
 
 	svc := rgta.New(session.Must(session.NewSession(
-		&aws.Config{
-			Region: aws.String(viper.GetString("region")),
-		},
+		&aws.Config{},
 	)))
 
 	// filterFile holds data structured in the output format of `grafiti parse`.

--- a/cmd/grafiti/main.go
+++ b/cmd/grafiti/main.go
@@ -35,7 +35,6 @@ var (
 
 // Grafiti-specific environment variables are prefixed with GRF_
 var envVarMap = map[string]string{
-	"AWS_REGION":          "region",
 	"GRF_START_HOUR":      "startHour",
 	"GRF_END_HOUR":        "endHour",
 	"GRF_START_TIMESTAMP": "startTimeStamp",

--- a/cmd/grafiti/parse.go
+++ b/cmd/grafiti/parse.go
@@ -105,9 +105,7 @@ func runParseCommand(cmd *cobra.Command, args []string) error {
 
 	// Parse resource data from the CloudTrail API.
 	svc := cloudtrail.New(session.Must(session.NewSession(
-		&aws.Config{
-			Region: aws.String(viper.GetString("region")),
-		},
+		&aws.Config{},
 	)))
 	if err := parseFromCloudTrail(svc); err != nil {
 		return fmt.Errorf("parse: %s", err)

--- a/cmd/grafiti/tag.go
+++ b/cmd/grafiti/tag.go
@@ -264,9 +264,7 @@ func tagFromStdIn() error {
 
 func tag(reader io.Reader) error {
 	svc := rgta.New(session.Must(session.NewSession(
-		&aws.Config{
-			Region: aws.String(viper.GetString("region")),
-		},
+		&aws.Config{},
 	)))
 	dec := json.NewDecoder(reader)
 
@@ -328,9 +326,7 @@ func tag(reader io.Reader) error {
 
 func tagUnsupportedResourceType(rt arn.ResourceType, nameSet ResourceNameSet) error {
 	sess := session.Must(session.NewSession(
-		&aws.Config{
-			Region: aws.String(viper.GetString("region")),
-		},
+		&aws.Config{},
 	))
 
 	switch arn.NamespaceForResource(rt) {

--- a/config.toml
+++ b/config.toml
@@ -3,7 +3,6 @@ endHour = 0
 startHour = -8
 # endTimeStamp = "2017-06-14T08:00:00Z" # RFC-3339 format in UTC
 # startTimeStamp = "2017-06-13T00:00:00Z"
-region = "us-west-2"
 maxNumRequestRetries = 8
 includeEvent = false
 tagPatterns = [

--- a/cronjob.yaml
+++ b/cronjob.yaml
@@ -16,12 +16,10 @@ spec:
             env:
               - name: AWS_REGION
                 value: ${AWS_REGION}
-              - name: AWS_CREDENTIAL_PROFILES_FILE
-                value: /etc/credentials
             name: grafiti-deleter
             image: your/registry/grafiti:v0.1.1
             volumeMounts:
-              - mountPath: /etc/credentials
+              - mountPath: /root/.aws/credentials
                 name: grafiti-aws-credentials
                 readOnly: true
               - mountPath: /opt/config.toml
@@ -33,7 +31,7 @@ spec:
               runAsUser: 1000
           volumes:
             - hostPath:
-                path: ~/.aws/credentials
+                path: ${HOME}/.aws/credentials
               name: grafiti-aws-credentials
             - hostPath:
                 path: ./config.toml

--- a/deleter/deleter.go
+++ b/deleter/deleter.go
@@ -27,7 +27,6 @@ func setUpAWSSession() *session.Session {
 	maxRetries := viper.GetInt("maxNumRequestRetries")
 	return session.Must(session.NewSession(
 		&aws.Config{
-			Region:  aws.String(viper.GetString("region")),
 			Retryer: retryer.DeleteRetryer{NumMaxRetries: maxRetries},
 		},
 	))

--- a/testdata/config/empty-test-config.toml
+++ b/testdata/config/empty-test-config.toml
@@ -1,1 +1,0 @@
-region = "us-west-2"

--- a/testdata/config/test-config.toml
+++ b/testdata/config/test-config.toml
@@ -3,7 +3,6 @@ endHour = 0
 startHour = -8
 # endTimeStamp = "2017-06-14T08:00:00Z" # RFC-3339 format in UTC
 # startTimeStamp = "2017-06-13T00:00:00Z"
-region = "us-west-2"
 maxNumRequestRetries = 8
 includeEvent = false
 tagPatterns = [


### PR DESCRIPTION
*: remove region config key in favor of specifying `AWS_REGION` in the environment

AWS SDK's automatically search for `AWS_*` environment variables. We do not need to inject these values ourselves.